### PR TITLE
 new option to destroy command

### DIFF
--- a/bin/oci-kvm
+++ b/bin/oci-kvm
@@ -80,7 +80,8 @@ def parse_args():
     destroy_parser.add_argument('-D', '--domain', action='store', type=str,
                                 help='Name of the virtual machine',
                                 required=True)
-
+    destroy_parser.add_argument('--destroy-disks', action='store_true',
+                                help='Also delete storage pool based disks')
     create_pool_parser.add_argument('-d', '--disk', action='store', type=str,
                                     help='Path to the root disk of the storage pool')
     create_pool_parser.add_argument('-N', '--netfshost', action='store', type=str,
@@ -138,7 +139,7 @@ def destroy_vm(args):
             The return value provided by the kvm virtual machine destroy
             call, 0 on success, 1 otherwise.
     """
-    return oci_utils.kvm.virt.destroy(args.domain)
+    return oci_utils.kvm.virt.destroy(args.domain, args.destroy_disks)
 
 
 def _create_pool_vm(args):

--- a/lib/oci_utils/impl/virt/virt_utils.py
+++ b/lib/oci_utils/impl/virt/virt_utils.py
@@ -14,7 +14,8 @@ from .. import sudo_utils
 from ..network_helpers import get_interfaces
 
 __all__ = ['get_domains_name', 'get_domain_state', 'get_domain_xml',
-           'get_interfaces_from_domain', 'get_disks_from_domain', 'get_domains_no_libvirtd', 'get_domain_xml_no_libvirtd']
+           'get_interfaces_from_domain', 'get_disks_from_domain', 'get_domains_no_libvirtd', 'get_domain_xml_no_libvirtd',
+           'find_storage_pool_volume_by_path']
 
 
 def get_domains_name():
@@ -294,3 +295,20 @@ def get_domain_xml_no_libvirtd(domain):
         return None
 
 
+def find_storage_pool_volume_by_path (conn, path):
+    """
+    find a libvirt Storage pool volume by path
+    parameters
+    ----------
+      conn : libvirt.virConnect
+            an active connection to hypervisor
+      path : str
+            volume path
+    Returns:
+        an instance of libvirt.virStorageVol or None if not found
+    """
+    for pool in conn.listAllStoragePools():
+        for volume in pool.listAllVolumes():
+            if volume.path() == path:
+                return volume
+    return None

--- a/man/man1/oci-kvm.1
+++ b/man/man1/oci-kvm.1
@@ -70,7 +70,7 @@ tools to manage.
 
 .SH OPTIONS
 .IP "--destroy-disks"
-For the destroy command, specify that all disks based on libviert storage pool must alos be deleted
+For the destroy command, specify that all disks based on libvirt storage pool must alos be deleted
 .IP "-D NAME, --domain NAME"
 For both the
 .B create

--- a/man/man1/oci-kvm.1
+++ b/man/man1/oci-kvm.1
@@ -22,6 +22,7 @@ oci-kvm \- install and remove KVM guests on Oracle Cloud Infrastructure instance
 
 .B oci-kvm destroy -D|--domain
 .I NAME
+.B [--destroy-disks]
 
 .B oci-kvm create-pool  -n|--name
 .I NAME
@@ -68,6 +69,8 @@ to stop automatically configuring VNICs and instead leaving them for the kvm
 tools to manage.
 
 .SH OPTIONS
+.IP "--destroy-disks"
+For the destroy command, specify that all disks based on libviert storage pool must alos be deleted
 .IP "-D NAME, --domain NAME"
 For both the
 .B create


### PR DESCRIPTION
New option to destroy command: --destroy-disks 
When specified by user , all disks attached to the guest which are based on Libvirt storage pool
are deleted during guest removal. 

tests done:
- destroy guest with only block storage
- destroy guest with pool based disks
- destroy guest with mixed type devices