### PR TITLE
fix typo in function name

### DIFF
--- a/lib/oci_utils/vnicutils.py
+++ b/lib/oci_utils/vnicutils.py
@@ -281,7 +281,7 @@ class VNICUtils(object):
         if vnic_id is None:
             return 0, 'IP %s is not configured.' % ipaddr
 
-        ret, info = self.__run_sec_vnic_script(['-d', '-e', ipaddr, vnic_id])
+        ret, info = self._run_sec_vnic_script(['-d', '-e', ipaddr, vnic_id])
         if ret == 0:
             if [ipaddr, vnic_id] in self.vnic_info['sec_priv_ip']:
                 self.vnic_info['sec_priv_ip'].remove([ipaddr, vnic_id])


### PR DESCRIPTION
fix regression in vnicutils module

===== from QA===

got failure when private ip deleted .  check form OCI console, the ip is deleted actually.

[root@junjing-ol7 opc]# oci-network-config  --del-private-ip 10.0.2.155
deconfigure secondary private IP 10.0.2.155
failed ot delete private ip: 'VNICUtils' object has no attribute '_VNICUtils__run_sec_vnic_script'

but from command line, it still shown 

CONFIG ADDR            SPREFIX         SBITS VIRTRT          NS         IND IFACE      VLTAG VLAN        STATE MAC               VNIC
-      10.0.2.150      10.0.2.0        24    10.0.2.1        -          0   ens3       -     -           UP    02:00:17:05:d7:0a ocid1.vnic.oc1.phx.abyhqljt6mx4z7i7qtiuhzu37jimtm7zuvp4tpd4v6itsowxgrbr5si2fqga
-      10.0.2.153      10.0.2.0        24    10.0.2.1        -          1   ens5       -     -           UP    02:00:17:05:ee:e0 ocid1.vnic.oc1.phx.abyhqljt3o5gv5mpm2xgsrjy6mlrfzohg2mulyzxqnnlssp2mgbwe3nxdqga
-      10.0.2.154      -               -     -               -          -   -          -     -           -     -                 -
-      10.0.2.155      -               -     -               -          -   -          -     -      