### PR TITLE
debug log file permission issue

### DIFF
--- a/lib/oci_utils/impl/__init__.py
+++ b/lib/oci_utils/impl/__init__.py
@@ -253,13 +253,14 @@ def setup_logging(forceDebug=False):
         handler = logging.handlers.SysLogHandler(address='/dev/log',
                                                  facility=logging.handlers.SysLogHandler.LOG_DAEMON)
     else:
-        try:
-            handler = logging.handlers.RotatingFileHandler(
-                '/var/tmp/oci-utils.log', mode='a', maxBytes=1024 * 1024, backupCount=3)
-            handler.setFormatter(formatter)
-            handler.setLevel(logging.NOTSET)
-        except StandardError, e:
-            print 'warning, cannot setup debug file : %s' % str(e)
+        if forceDebug:
+            try:
+                handler = logging.handlers.RotatingFileHandler(
+                    '/var/tmp/oci-utils.log', mode='a', maxBytes=1024 * 1024, backupCount=3)
+                handler.setFormatter(formatter)
+                handler.setLevel(logging.NOTSET)
+            except StandardError, e:
+                print 'warning, cannot setup debug file : %s' % str(e)
 
     logger = logging.getLogger('oci-utils')
     logger.setLevel(logging.INFO)


### PR DESCRIPTION
When running CLIs under opc user , some warnings can be raised about the log file creation
```#oci-kvm
warning, cannot setup debug file : [Errno 13] Permission denied: '/var/tmp/oci-utils.log'
....
```
This debug log is used during development phase. In order to hide the warning in production
we'll also defer debug log file creation only when developper has activated the debug

Testing:
running 'oci-kvm' cli user OPC user do not raise any warning anymore


