### PR TITLE
fix regression in vnic and subnet data api

### DIFF
--- a/bin/oci-network-config
+++ b/bin/oci-network-config
@@ -173,8 +173,12 @@ def api_show_network_config():
         print "     MAC address: %s" % vnic.get_mac_address()
         print "     Public IP address: %s" % vnic.get_public_ip()
         print "     Private IP address: %s" % vnic.get_private_ip()
-        print "     Subnet: %s (%s)" % (vnic.get_subnet().get_display_name(),
-                                        vnic.get_subnet().get_cidr_block())
+        if vnic.get_subnet() is not None:
+            print "     Subnet: %s (%s)" % (vnic.get_subnet().get_display_name(),
+                                            vnic.get_subnet().get_cidr_block())
+        else:
+            print "     Subnet: Not found"
+
         privips = vnic.all_private_ips()
         if len(privips) > 0:
             print "     Private IP addresses:"

--- a/bin/oci-network-inspector
+++ b/bin/oci-network-inspector
@@ -161,10 +161,7 @@ def main():
                 if vnic:
                     print "         Vnic: %s (%s)" % \
                           (vnic.get_ocid(), vnic.get_state())
-                    # subnet ips
-                    # FIXME: This is a temporary work around - the OCI-UTILS API
-                    #        need to be fixed to allow retrieving the property
-                    if not subnet._data.prohibit_public_ip_on_vnic:
+                    if subnet.is_public_ip_on_vnic_allowed():
                         print "         Vnic PublicIP: %s" % \
                               vnic.get_public_ip()
                     instance = vnic.get_instance()
@@ -172,10 +169,7 @@ def main():
                           (instance.get_hostname(), instance.get_state())
                     print "         Instance ocid: %s" % (instance.get_ocid())
                 else:
-                    # FIXME: The get_vnic() API is broken
-                    # vnic_id = ip.get_vnic().get_ocid()
-                    # Following line is a work around only
-                    vnic_id = ip._data.vnic_id
+                    vnic_id = ip.get_vnic_ocid()
                     print "         Vnic: %s(%s)" % (vnic_id, "NotFound")
                     print "         Instance: (maybe)%s(%s)" % \
                           (ip.get_display_name(), "NotFound")

--- a/lib/oci_utils/impl/oci_resources.py
+++ b/lib/oci_utils/impl/oci_resources.py
@@ -76,7 +76,6 @@ class OCICompartment(OCIAPIAbstractResource):
         self._vcns = None
         self._vnics = None
         self._volumes = None
-        self.data = compartment_data
 
     def __str__(self):
         """
@@ -1483,17 +1482,25 @@ class OCIPrivateIP(OCIAPIAbstractResource):
 
     def get_vnic(self):
         """
-        Get the virtual network interface card data.
+        Get the vNIC of this private ip.
 
         Returns
         -------
-            dict
-                The VNIC data.
+            OCIVNIC
+                The VNIC instance.
         """
         return self._oci_session.get_vnic(self._data.vnic_id)
 
     def get_vnic_ocid(self):
-        return self.data.vnic_id
+        """
+        Gets the VNIC id.
+        Note : return the value defined in the metadata which may differ
+               from instance returned by get_vnic() method
+        returns:
+        --------
+            str : vnic ocid
+        """
+        return self._data.vnic_id
 
     def get_address(self):
         """
@@ -1813,6 +1820,11 @@ class OCISubnet(OCIAPIAbstractResource):
                 The cidr block.
         """
         return self._data.cidr_block
+    def is_public_ip_on_vnic_allowed(self):
+        """
+
+        """
+        return not self._data.prohibit_public_ip_on_vnic
 
     def get_vcn_id(self):
         """

--- a/lib/oci_utils/impl/oci_resources.py
+++ b/lib/oci_utils/impl/oci_resources.py
@@ -1822,7 +1822,11 @@ class OCISubnet(OCIAPIAbstractResource):
         return self._data.cidr_block
     def is_public_ip_on_vnic_allowed(self):
         """
-
+        Checks if public PI allowed in vnic of this subnet
+        Returns:
+        --------
+            bool
+                True if allowed
         """
         return not self._data.prohibit_public_ip_on_vnic
 


### PR DESCRIPTION
fix regression around oci_resource class private data
test:
 run oci-network-inspector successfully 