### PR TITLE
fix version data difference between setup and spec file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ class sync_rpm(create_rpm):
 
 setup(
     name="oci-utils",
-    version="0.10.0",
+    version="0.10.1",
     author="Laszlo Peter, Qing Lin",
     author_email="laszlo.peter@oracle.com, qing.lin@oracle.com",
     description="Oracle Cloud Infrastructure utilities",


### PR DESCRIPTION
fixed version data discrepancy between setup.py and spec file, causing the setup.py create_rpm to fail due to the generation of the wrong version info in the tar ball.
tests:
successfully ran setup.py create_rpm 