### PR TITLE
remove any stale log file during install or update

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -63,6 +63,10 @@ Requires: %{name} = %{version}-%{release}
 %description outest
 Utilities unit tests
 
+%pre
+# some old version of oci-utils, used to leave this behind.
+%{__rm} -f /var/tmp/oci-utils.log*
+
 %prep
 %setup -q -n %{name}-%{version}
 


### PR DESCRIPTION
test case 1 
- create log files
- install oci-utils rpm 
- check that files are gone

test case 2 
- install previous version of oci-utils 
- check that log file are created
- update oci-utils
- check that files are gone