### PR TITLE
fix merge regression

### DIFF
--- a/bin/oci-network-config
+++ b/bin/oci-network-config
@@ -173,10 +173,10 @@ def api_show_network_config():
         print "     MAC address: %s" % vnic.get_mac_address()
         print "     Public IP address: %s" % vnic.get_public_ip()
         print "     Private IP address: %s" % vnic.get_private_ip()
-       
+
         _subn = vnic.get_subnet()
         if _subn is not None:
-            print "     Subnet: %s (%s)" % (_subn.get_display_name(),
+            print "     Subnet: %s (%s)" % (_subn.get_display_name(), _subn)
         else:
             print "     Subnet: Not found"
 

--- a/bin/oci-network-inspector
+++ b/bin/oci-network-inspector
@@ -81,10 +81,12 @@ def main():
     if args.compartment:
         if args.compartment.startswith('ocid1.compartment.oc1..'):
             comp = sess.get_compartment(compartment_id=args.compartment)
-            comps.append(comp)
+            if comp is not None:
+                comps.append(comp)
         else:
             comp = sess.find_compartments(args.compartment)
-            comps += comp
+            if comp is not None:
+                comps += comp
     else:
         comp = sess.all_compartments()
         comps += comp
@@ -93,10 +95,12 @@ def main():
     if args.vcn:
         if args.vcn.startswith('ocid1.vcn.oc1.'):
             vcn = sess.get_vcn(args.vcn)
-            vcns.append(vcn)
+            if vcn is not None:
+                vcns.append(vcn)
         else:
             vcn = sess.find_vcns(args.vcn)
-            vcns += vcn
+            if vcn is not None:
+                vcns += vcn
     else:
         # get all vcns for the compartment.
         for comp in comps:

--- a/lib/oci_utils/impl/oci_resources.py
+++ b/lib/oci_utils/impl/oci_resources.py
@@ -1692,8 +1692,8 @@ class OCISecurityList(OCIAPIAbstractResource):
             src = "---"
             desport = "-"
             srcport = "-"
-            if rule.protocol == 6 or rule.protocol == 17:
-                if rule.protocol == 6:
+            if rule.protocol == "6" or rule.protocol == "17":
+                if rule.protocol == "6":
                     option = rule.tcp_options
                 else:
                     option = rule.udp_options
@@ -1718,7 +1718,7 @@ class OCISecurityList(OCIAPIAbstractResource):
 
                 except Exception:
                     srcport = "-"
-            elif rule.protocol == 1:
+            elif rule.protocol == "1":
                 srcport = "-"
                 option = rule.icmp_options
                 try:


### PR DESCRIPTION
Fix wrong usage of protocol number while displaying security egress rules
Fix merge regression in oci-network-config

test done :
- run oci-network-config
- run oci-network-inspector commands to display compartment  