### PR TITLE
Added VLAN Tag workaround for VM shapes for case where the vNIC metadata

### DIFF
--- a/libexec/secondary_vnic_all_configure.sh
+++ b/libexec/secondary_vnic_all_configure.sh
@@ -151,6 +151,15 @@ oci_vcn_md_read() {
     MD_VNICS=($(grep -w vnicId "$tmpfile" | cut -f 4 -d '"'))
     MD_NIC_IS=($(grep -w nicIndex "$tmpfile" | cut -f 2 -d ':' | tr -d ' '))
 
+    # for VM shapes tags are not required
+    if [ ${#MD_NIC_IS[@]} -eq 0 ]; then
+        i=$((${#MD_MACS[@]} - ${#MD_VLTAGS[@]}))
+        while [[ $i -gt 0 ]]; do
+            MD_VLTAGS=(${MD_VLTAGS[@]} 1)
+            i=-1
+        done
+    fi
+
     # do some validity checks on md data
     [ ${#MD_MACS[@]} -eq ${#MD_ADDRS[@]} ] || oci_vcn_err "invalid metadata: MAC or IP addresses are missing"
     [ ${#MD_MACS[@]} -eq ${#MD_VLTAGS[@]} ] || oci_vcn_err "invalid metadata: MAC or VLAN tags are missing"


### PR DESCRIPTION
The VM shape metatdata does not always contain a VLAN tag from the vNIC and since it is not required on VM shapes we can safely ignore the it. The workaround will create a fake VLAN Tag on VM shapes when this happens for the vNICS missing the metadata key