### PR TITLE
fix crash of oci-kvm when no action is given

### DIFF
--- a/lib/oci_utils/impl/network_helpers.py
+++ b/lib/oci_utils/impl/network_helpers.py
@@ -89,7 +89,7 @@ def get_interfaces():
                 for line in subprocess.check_output(
                         ['/usr/sbin/ip', 'link', 'show', n]).splitlines():
                     line = line.strip()
-                    if not line.startswith('vf '):
+                    if not str(line).startswith('vf '):
                         continue
 
                     ents = line.split(' ')

--- a/lib/oci_utils/impl/oci_resources.py
+++ b/lib/oci_utils/impl/oci_resources.py
@@ -138,7 +138,8 @@ class OCICompartment(OCIAPIAbstractResource):
         except oci_sdk.exceptions.ServiceError:
             # ignore these, it means the current user has no
             # permission to list the instances in the compartment
-            pass
+            OCICompartment._logger.debug('user has no permission to list the instances in the compartment')
+            
         self._instances = instances
         return instances
 
@@ -237,7 +238,8 @@ class OCICompartment(OCIAPIAbstractResource):
         except oci_sdk.exceptions.ServiceError:
             # ignore these, it means the current user has no
             # permission to list the vcns in the compartment
-            pass
+            OCICompartment._logger.debug('current user has no permission to list the vcns in the compartment')
+            
         self._vcns = vcns
         return vcns
 
@@ -300,6 +302,7 @@ class OCICompartment(OCIAPIAbstractResource):
         except oci_sdk.exceptions.ServiceError:
             # ignore these, it means the current user has no
             # permission to list the volumes in the compartment
+            OCICompartment._logger.debug('current user has no permission to list the volumes in the compartment')
             pass
         if availability_domain is None:
             self._volumes = bs
@@ -530,6 +533,7 @@ class OCIInstance(OCIAPIAbstractResource):
             except oci_sdk.exceptions.ServiceError:
                 # ignore these, it means the current user has no
                 # permission to list the instances in the compartment
+                OCIInstance._logger.debug('current user has no permission to list the vcns in the compartment')
                 pass
         self._vnics = vnics
         return self._vnics

--- a/lib/oci_utils/impl/virt/oci-kvm-main.py
+++ b/lib/oci_utils/impl/virt/oci-kvm-main.py
@@ -122,7 +122,7 @@ def parse_args():
     parser.add_argument('--help', action='help',
                         help='Display this help')
 
-    return parser.parse_args()
+    return parser
 
 
 def create_vm(args):
@@ -319,7 +319,11 @@ def main():
                    _create_network: _create_network_vm,
                    _delete_network: _delete_network_vm}
 
-    args = parse_args()
+    parser = parse_args()
+    args = parser.parse_args()
+    if args.mode is None:
+        parser.print_help()
+        sys.exit(0)
 
     return subcommands[args.mode](args)
 


### PR DESCRIPTION
fix crash on python3 of oci-kvm due to str usage instead of bytes 
add few more debug messages to ease troubleshooting