### PR TITLE
Added oci-image-migrate utility, migrate on premise images to OCI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include libexec/oci-kvm-network-script
 include tests/*.py
 include data/*.service
 include data/oci-image-cleanup.conf
+include data/oci-migrate-conf.yaml
 include data/00-oci-utils.conf
 include data/10-oci-kvm.conf
 include data/91-oci-kvm.preset

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+Version 0.10.2-1
+- Added oci-image-migrate utility
+
 Version 0.10.2
 - Update to use Python 3 on OL8
 

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Version 0.10.2-1
+Version 0.11.0
 - Added oci-image-migrate utility
 
 Version 0.10.2

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: oci-utils
-Version: 0.10.2
+Version: 0.10.2-1
 Summary: Oracle Cloud Infrastructure utilities
 Home-page: http://github.com/oracle/oci-utils/
 Author: Laszlo Peter

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: oci-utils
-Version: 0.10.2-1
+Version: 0.11.0
 Summary: Oracle Cloud Infrastructure utilities
 Home-page: http://github.com/oracle/oci-utils/
 Author: Laszlo Peter

--- a/bin/oci-image-migrate
+++ b/bin/oci-image-migrate
@@ -1,41 +1,15 @@
 #!/bin/sh
-
-# Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+#
+# Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # http://oss.oracle.com/licenses/upl.
 
-# The oci-image-migrate utility assists with migrating on-premise instance to the
-# Oracle Cloud Infrastructure.  See the manual page for more information.
 
-_PY=""
-_PY2=/usr/bin/python2
+# This utility assists with configuring iscsi storage on Oracle Cloud
+# Infrastructure instances.  See the manual page for more information.
+
 _PY3=/usr/bin/python3
-s_dir=""
-
-# priority given to python3 
-if [ -x ${_PY3} ]
-then
-        # also be sure that py3 compatible code is installed
-        s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
-        if [ -n "${s_dir}" ]
-        then
-	   _PY=${_PY3}
-        fi
-fi
-if [ -z ${_PY} ]
-then
-   # still have to look for correct py
-   if [ -x ${_PY2} ]
-   then
-      _PY=${_PY2}
-   else
-      _PY=/usr/bin/python
-   fi
-   # find where actual script is.
-   s_dir=`${_PY} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))'`
-
-fi
-
-exec ${_PY}  ${s_dir}/oci-image-migrate-main.py $@
+s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
 
 
+exec ${_PY3}  ${s_dir}/oci-image-migrate-main.py $@

--- a/bin/oci-image-migrate
+++ b/bin/oci-image-migrate
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+# The oci-image-migrate utility assists with migrating on-premise instance to the
+# Oracle Cloud Infrastructure.  See the manual page for more information.
+
+_PY=""
+_PY2=/usr/bin/python2
+_PY3=/usr/bin/python3
+s_dir=""
+
+# priority given to python3 
+if [ -x ${_PY3} ]
+then
+        # also be sure that py3 compatible code is installed
+        s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
+        if [ -n "${s_dir}" ]
+        then
+	   _PY=${_PY3}
+        fi
+fi
+if [ -z ${_PY} ]
+then
+   # still have to look for correct py
+   if [ -x ${_PY2} ]
+   then
+      _PY=${_PY2}
+   else
+      _PY=/usr/bin/python
+   fi
+   # find where actual script is.
+   s_dir=`${_PY} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))'`
+
+fi
+
+exec ${_PY}  ${s_dir}/oci-image-migrate-main.py $@
+
+

--- a/bin/oci-image-migrate-import
+++ b/bin/oci-image-migrate-import
@@ -1,0 +1,32 @@
+# Oracle Cloud Infrastructure.  See the manual page for more information.
+
+_PY=""
+_PY2=/usr/bin/python2
+_PY3=/usr/bin/python3
+s_dir=""
+
+# priority given to python3 
+if [ -x ${_PY3} ]
+then
+        # also be sure that py3 compatible code is installed
+        s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
+        if [ -n "${s_dir}" ]
+        then
+	   _PY=${_PY3}
+        fi
+fi
+if [ -z ${_PY} ]
+then
+   # still have to look for correct py
+   if [ -x ${_PY2} ]
+   then
+      _PY=${_PY2}
+   else
+      _PY=/usr/bin/python
+   fi
+   # find where actual script is.
+   s_dir=`${_PY} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))'`
+
+fi
+
+exec ${_PY}  ${s_dir}/oci-image-migrate-import.py $@

--- a/bin/oci-image-migrate-import
+++ b/bin/oci-image-migrate-import
@@ -1,32 +1,15 @@
-# Oracle Cloud Infrastructure.  See the manual page for more information.
+#!/bin/sh
+#
+# Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
 
-_PY=""
-_PY2=/usr/bin/python2
+
+# This utility assists with configuring iscsi storage on Oracle Cloud
+# Infrastructure instances.  See the manual page for more information.
+
 _PY3=/usr/bin/python3
-s_dir=""
+s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
 
-# priority given to python3 
-if [ -x ${_PY3} ]
-then
-        # also be sure that py3 compatible code is installed
-        s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
-        if [ -n "${s_dir}" ]
-        then
-	   _PY=${_PY3}
-        fi
-fi
-if [ -z ${_PY} ]
-then
-   # still have to look for correct py
-   if [ -x ${_PY2} ]
-   then
-      _PY=${_PY2}
-   else
-      _PY=/usr/bin/python
-   fi
-   # find where actual script is.
-   s_dir=`${_PY} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))'`
 
-fi
-
-exec ${_PY}  ${s_dir}/oci-image-migrate-import.py $@
+exec ${_PY3}  ${s_dir}/oci-image-migrate-import-main.py $@

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
-Version: 0.10.2
-Release: 3%{?dist}
+Version: 0.11.0
+Release: 0%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -165,7 +165,7 @@ rm -rf %{buildroot}
 %{__l_python_sitelib}/oci_utils/impl/sudo_utils*
 %{__l_python_sitelib}/oci_utils/impl/oci-image-migrate*
 %{__l_python_sitelib}/oci_utils/migrate*
-%{_datadir}/man/man1/oci-image-migrate.1.gz
+%{_datadir}/man/man1/oci-image-migrate*1.gz
 %config %{_sysconfdir}/oci-utils/oci-migrate-conf.yaml
 
 %post kvm

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
-Version: 0.10.2-1
-Release: 1%{?dist}
+Version: 0.10.2
+Release: 2%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -169,7 +169,7 @@ rm -rf %{buildroot}
 %systemd_preun oci-kvm-config.service
 
 %changelog
-* Thu Dec 12 2019 Guido Tijskens <guido.tijskens@oracle.com> -- 0.10.2-1
+* Thu Dec 12 2019 Guido Tijskens <guido.tijskens@oracle.com> -- 0.10.2-2
 - Added oci-image-migrate utility.
 
 * Wed Dec 4 2019 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.10.2

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,5 +1,5 @@
 Name: oci-utils
-Version: 0.10.2
+Version: 0.10.2-1
 Release: 1%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
@@ -75,6 +75,15 @@ Requires: %{name} = %{version}-%{release}
 %description outest
 Utilities unit tests
 
+%package migrate
+Summary: Migrate vm from on-premise to the OCI
+Group: Development/Tools
+Requires: util-linux
+Requires: parted
+Requires: qemu-img >= 3.1
+%description migrate
+Utilities for migrating on-premise guests to Oracle Cloud Infrastructure.
+
 %pre
 # some old version of oci-utils, used to leave this behind.
 %{__rm} -f /var/tmp/oci-utils.log*
@@ -114,11 +123,14 @@ rm -rf %{buildroot}
 %exclude %dir %{__l_python_sitelib}/oci_utils/kvm
 %exclude %{__l_python_sitelib}/oci_utils/kvm/*
 %exclude %{_bindir}/oci-kvm
+%exclude %{_bindir}/oci-image-migrate
 %exclude %{_datadir}/man/man1/oci-kvm.1.gz
+%exclude %{_datadir}/man/man1/oci-image-migrate.1.gz
 %defattr(-,root,root)
 %{__l_python_sitelib}/oci_utils*
 %{_bindir}/oci-*
 %exclude %{_bindir}/oci-kvm
+%exclude %{_bindir}/oci-image-migrate
 %{_libexecdir}/
 %{_sysconfdir}/systemd/system/ocid.service
 %{_prefix}/lib/systemd/system-preset/91-oci-utils.preset
@@ -144,6 +156,12 @@ rm -rf %{buildroot}
 %files outest
 /opt/oci-utils
 
+%files migrate
+%{_bindir}/oci-image-migrate
+%{__l_python_sitelib}/oci_utils/migrate*
+%{_datadir}/man/man1/oci-image-migrate.1.gz
+%config %{_sysconfdir}/oci-utils/oci-migrate-conf.yaml
+
 %post kvm
 %systemd_post oci-kvm-config.service
 
@@ -151,6 +169,9 @@ rm -rf %{buildroot}
 %systemd_preun oci-kvm-config.service
 
 %changelog
+* Thu Dec 12 2019 Guido Tijskens <guido.tijskens@oracle.com> -- 0.10.2-1
+- Added oci-image-migrate utility.
+
 * Wed Dec 4 2019 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.10.2
 - Update to use Python 3 on OL8
 

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
 Version: 0.10.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -158,6 +158,7 @@ rm -rf %{buildroot}
 
 %files migrate
 %{_bindir}/oci-image-migrate
+%{_bindir}/oci-image-migrate-import
 %{__l_python_sitelib}/oci_utils/__init__*
 %{__l_python_sitelib}/oci_utils/exceptions*
 %{__l_python_sitelib}/oci_utils/impl/__init__*
@@ -174,6 +175,9 @@ rm -rf %{buildroot}
 %systemd_preun oci-kvm-config.service
 
 %changelog
+* Tue Jan 7 2020 Guido Tijskens <guido.tijskens@oracle.com> -- 0.10.2-3
+- Added oci-image-migrate-import utility
+
 * Thu Dec 12 2019 Guido Tijskens <guido.tijskens@oracle.com> -- 0.10.2-2
 - Added oci-image-migrate utility.
 

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -158,6 +158,11 @@ rm -rf %{buildroot}
 
 %files migrate
 %{_bindir}/oci-image-migrate
+%{__l_python_sitelib}/oci_utils/__init__*
+%{__l_python_sitelib}/oci_utils/exceptions*
+%{__l_python_sitelib}/oci_utils/impl/__init__*
+%{__l_python_sitelib}/oci_utils/impl/sudo_utils*
+%{__l_python_sitelib}/oci_utils/impl/oci-image-migrate*
 %{__l_python_sitelib}/oci_utils/migrate*
 %{_datadir}/man/man1/oci-image-migrate.1.gz
 %config %{_sysconfdir}/oci-utils/oci-migrate-conf.yaml

--- a/data/oci-migrate-conf.yaml
+++ b/data/oci-migrate-conf.yaml
@@ -148,6 +148,7 @@ partition_types :
 # list of valid boot configurations.
 valid_boot_types : 
     - 'BIOS'
+    - 'UEFI'
 #
 # list of directories required for a normal boot of a linux type os; if
 # those directories reside in separate partitions, those partition have to
@@ -211,6 +212,9 @@ default_nwm_conf_file :
    - ''
    - '[ifupdown]'
    - 'managed=false'
+   - ''
+   - '[keyfile]'
+   - 'unmanaged-devices='
    - ''
    - '[device]'
    - 'wifi.scan-rand-mac-address=no'

--- a/data/oci-migrate-conf.yaml
+++ b/data/oci-migrate-conf.yaml
@@ -1,0 +1,238 @@
+# ----------------------------------------------------------------------------
+# Configuration and status data with respect to the oci-image-migrate.
+# ----------------------------------------------------------------------------
+#
+# dummy format key
+dummy_format_key : '01234567'
+#
+# log file path, without .log extension, timestamp and extension added runtime.
+# logfilepath : /var/tmp/oci-image-migrate
+#
+# result file path without extension, image references are added runtime,
+resultfilepath : /var/tmp/oci-image-migrate
+#
+# Dictionary containing utilities which might be needed with the packages
+# which provide them.
+helpers_list : 
+    qemu-nbd   : qemu-img
+    qemu-img   : qemu-img
+    blkid      : util-linux
+    lsblk      : util-linux
+    sfdisk     : util-linux
+    fdisk      : util-linux
+    parted     : parted,
+    partx      : util-linux
+    lvmdiskscan: lvm2
+    oci        : oci-cli
+#
+# oci configuration file
+ociconfigfile : /root/.oci/config
+#
+# recognised file system types.
+filesystem_types :
+    - ext2
+    - ext3
+    - ext4
+    - xfs
+    - btrfs
+    - ocfs2
+logical_vol_types : 
+    - LVM2_member
+#
+# partition names and types to be ignored.
+partition_to_skip : 
+    - swap
+    - none
+    - dummy
+#
+# recognised partition types.
+partition_types : 
+    00:  Empty
+    01:  FAT12
+    02:  XENIX root
+    03:  XENIX usr
+    04:  FAT16 <32M
+    05:  Extended
+    06:  FAT16
+    07:  HPFS/NTFS
+    08:  AIX
+    09:  AIX bootable
+    0a:  OS/2 Boot Manag
+    0b:  W95 FAT32
+    0c:  W95 FAT32 (LBA)
+    0e:  W95 FAT16 (LBA)
+    0f:  W95 Extd (LBA)
+    10:  OPUS
+    11:  Hidden FAT12
+    12:  Compaq diagnost
+    14:  Hidden FAT16 <32>
+    16:  Hidden FAT16
+    17:  Hidden HPFS/NTFS
+    18:  AST SmartSleep
+    1b:  Hidden W95 FAT32
+    1c:  Hidden W95 FAT32
+    1e:  Hidden W95 FAT16
+    24:  NEC DOS
+    39:  Plan 9
+    3c:  PartitionMagic
+    40:  Venix 80286
+    41:  PPC PReP Boot
+    42:  SFS
+    4d:  QNX4.x
+    4e:  QNX4.x 2nd part
+    4f:  QNX4.x 3rd part
+    50:  OnTrack DM
+    51:  OnTrack DM6 Aux
+    52:  CP/M
+    53:  OnTrack DM6 Aux
+    54:  OnTrackDM6
+    55:  EZ-Drive
+    56:  Golden Bow
+    5c:  Priam Edisk
+    61:  SpeedStor
+    63:  GNU HURD or Sys
+    64:  Novell Netware
+    65:  Novell Netware
+    70:  DiskSecure Mult
+    75:  PC/IX
+    80:  Old Minix
+    81:  Minix / old Lin
+    82:  Linux swap / Solaris x86
+    83:  Linux
+    84:  OS/2 hidden C
+    85:  Linux extended
+    86:  NTFS volume set
+    87:  NTFS volume set
+    88:  Linux plaintext
+    8e:  Linux LVM
+    93:  Amoeba
+    94:  Amoeba BBT
+    9f:  BSD/OS
+    a0:  IBM Thinkpad hi
+    a5:  FreeBSD
+    a6:  OpenBSD
+    a7:  NeXTSTEP
+    a8:  Darwin UFS
+    a9:  NetBSD
+    ab:  Darwin boot
+    af:  HFS / HFS+
+    b7:  BSDI fs
+    b8:  BSDI swap
+    bb:  Boot Wizard hid
+    be:  Solaris boot
+    bf:  Solaris
+    c1:  DRDOS/sec (FAT-12)
+    c4:  DRDOS/sec (FAT-16)
+    c6:  DRDOS/sec (FAT-16B)
+    c7:  Syrinx
+    da:  Non-FS data
+    db:  CP/M / CTOS / .
+    de:  Dell Utility
+    df:  BootIt
+    e1:  DOS access
+    e3:  DOS R/O
+    e4:  SpeedStor
+    eb:  BeOS fs
+    ee:  GPT
+    ef:  EFI (FAT-12/16/
+    f0:  Linux/PA-RISC b
+    f1:  SpeedStor
+    f4:  SpeedStor
+    f2:  DOS secondary
+    fb:  VMware VMFS
+    fc:  VMware VMKCORE
+    fd:  Linux raid auto
+    fe:  LANstep
+    ff:  BBT
+#
+# list of valid boot configurations.
+valid_boot_types : 
+    - 'BIOS'
+#
+# list of directories required for a normal boot of a linux type os; if
+# those directories reside in separate partitions, those partition have to
+# be in the same image file.
+essential_dir_list :
+    - /boot
+    - /bin
+    - /etc
+    - /home
+    - /lib
+    - /opt
+    - /sbin
+    - /srv
+    - /usr
+    - /var
+
+# ifcfg
+default_ifcfg : /etc/sysconfig/network-scripts
+default_ifcfg_config : 
+    - TYPE="Ethernet"
+    - PROXY_METHOD="none"
+    - BROWSER_ONLY="no"
+    - BOOTPROTO="dhcp"
+    - DEFROUTE="yes"
+    - IPV4_FAILURE_FATAL="no"
+    - IPV6INIT="yes"
+    - IPV6_AUTOCONF="yes"
+    - IPV6_DEFROUTE="yes"
+    - IPV6_FAILURE_FATAL="no"
+    - IPV6_ADDR_GEN_MODE="stable-privacy"
+    - NAME="_XXXX_"
+    - DEVICE="_XXXX_"
+    - NM_CONTROLLED="no"
+    - ONBOOT="yes"
+#
+# interfaces file
+default_interfaces : /etc/network
+default_interfaces_config :
+    - '# The loopback network interface'
+    - auto lo
+    - iface lo inet loopback
+    - '# The primary network interface'
+    - auto _XXXX_
+    - iface _XXXX_ inet dhcp
+#
+# netplan
+default_netplan : /etc/netplan
+default_netplan_file : 10-default-network.yaml
+default_netplan_config :
+    network:
+        ethernets :
+            _XXXX_ :
+                dhcp4: true
+#
+# network manager
+default_nwmconfig : /etc/NetworkManager/NetworkManager.conf
+default_nwconnections : /etc/NetworkManager/system-connections
+default_nwm_conf_file : 
+   - '[main]'
+   - 'plugins=ifupdown,keyfile'
+   - ''
+   - '[ifupdown]'
+   - 'managed=false'
+   - ''
+   - '[device]'
+   - 'wifi.scan-rand-mac-address=no'
+#
+# systemd_networkd
+default_systemd :
+    - /etc/systemd/network
+    - /lib/systemd/network
+default_systemd_file : /etc/systemd/network/10-default-cfg.network
+default_systemd_config :
+    - '[Match]'
+    - 'Name=_XXXX_'
+    - '[Network]'
+    - 'DHCP=ipv4'
+#
+# list of supported operating systems.
+valid_os :
+    - ORACLE LINUX SERVER
+    - RHEL
+    - CENTOS
+    - UBUNTU
+#
+# cloud-config
+cloudconfig_file : /etc/cloud/cloud.cfg
+default_clouduser : opc

--- a/data/oci-migrate-conf.yaml
+++ b/data/oci-migrate-conf.yaml
@@ -42,6 +42,10 @@ logical_vol_types :
 # partition names and types to be ignored.
 partition_to_skip : 
     - swap
+    - /dev/shm
+    - /sys
+    - /dev/pts
+    - /proc
     - none
     - dummy
 #

--- a/data/oci-migrate-conf.yaml
+++ b/data/oci-migrate-conf.yaml
@@ -1,3 +1,9 @@
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+# Oracle Cloud Infrastructure.  See the manual page for more information.
+
 # ----------------------------------------------------------------------------
 # Configuration and status data with respect to the oci-image-migrate.
 # ----------------------------------------------------------------------------

--- a/lib/oci_utils/impl/oci-image-migrate-import-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-import-main.py
@@ -5,27 +5,31 @@
 # at http://oss.oracle.com/licenses/upl.
 
 """
-Script to import an on-premise virtual server from an object storage to the custom images 
-in the Oracle Cloud Infrastructure. An image which passed the checks and modifications 
-of - and was uploaded by the oci-image-migrate utility should import fine.
+Script to import an on-premise virtual server from an object storage to the
+custom images in the Oracle Cloud Infrastructure. An image which passed the
+checks and modifications of - and was uploaded by the oci-image-migrate
+utility should import fine.
 """
 import argparse
 import json
 import logging.config
-import six
+import os
 import sys
-import time
 
 from oci_utils.migrate import console_msg, exit_with_msg, read_yn
 from oci_utils.migrate import migrate_tools
 from oci_utils.migrate import migrate_utils
+
+if sys.version_info.major < 3:
+    exit_with_msg('Python version 3 is a requirement to run this utility.')
 
 _logger = logging.getLogger('oci-utils.import_ci')
 
 
 def parse_args():
     """
-    Parse the command line arguments and return an object representing the command
+    Parse the command line arguments and return an object representing the
+    command
     line as returned by the argparse's parse-args().
     arguments:
     -i|--image-name <image name>; mandatory.
@@ -42,14 +46,16 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Utility to import a (verified and modified) on-premise '
                     'legacy images which was uploaded to object storage in '
-                    'the custom images folderof the Oracle Cloud Infrastructure.',
+                    'the custom images folderof the Oracle Cloud '
+                    'Infrastructure.',
         add_help=False)
     #
     parser.add_argument('-i', '--image-name',
                         action='store',
                         dest='imagename',
                         required=True,
-                        help='The name of the object representing the uploaded image.')
+                        help='The name of the object representing the '
+                             'uploaded image.')
     parser.add_argument('-b', '--bucket-name',
                         action='store',
                         dest='bucketname',
@@ -74,6 +80,11 @@ def parse_args():
                              'is PARAVIRTUALIZED.',
                         choices=['PARAVIRTUALIZED', 'EMULATED', 'NATIVE'],
                         default='PARAVIRTUALIZED')
+    parser.add_argument('--verbose', '-v',
+                        action='store_true',
+                        dest='verboseflag',
+                        default=False,
+                        help='Show verbose information.')
     parser.add_argument('--help', action='help', help='Display this help')
     parser._optionals.title = 'Arguments'
     args = parser.parse_args()
@@ -81,31 +92,35 @@ def parse_args():
         args.displayname = args.imagename
     return args
 
+
 def main():
     #
     # command line
     cmdlineargs = parse_args()
-    console_msg(msg = 'Importing %s from %s into %s as %s and setting '
-                      'launchmode to %s.' % (cmdlineargs.imagename,
-                                             cmdlineargs.bucketname,
-                                             cmdlineargs.bucketname,
-                                             cmdlineargs.displayname,
-                                             cmdlineargs.launchmode))
+    console_msg(msg='Importing %s from %s into %s as %s and setting '
+                    'launchmode to %s.' % (cmdlineargs.imagename,
+                                           cmdlineargs.bucketname,
+                                           cmdlineargs.bucketname,
+                                           cmdlineargs.displayname,
+                                           cmdlineargs.launchmode))
     compartment = cmdlineargs.compartmentname
     bucket = cmdlineargs.bucketname
     objectname = cmdlineargs.imagename
     displayname = cmdlineargs.displayname
     launchmode = cmdlineargs.launchmode
+    verboseflag = cmdlineargs.verboseflag
     #
     # oci config file 
     try:
         ocicfg = migrate_utils.get_oci_config()
         console_msg('Found oci config file')
         tenancy = ocicfg['tenancy']
-        console_msg(msg = 'tenancy = %s' % tenancy)
+        console_msg(msg='Tenancy = %s' % tenancy)
         _logger.debug('Tenancy: %s' % tenancy)
-        cmd = ['oci', 'iam', 'compartment', 'list', '-c', '%s' % tenancy, '--all']
-        console_msg(msg='running: %s' % cmd)
+        cmd = ['oci', 'iam', 'compartment', 'list', '-c', '%s' % tenancy,
+               '--all']
+        if verboseflag:
+            console_msg(msg='Running: %s' % cmd)
         cmpdict = json.loads(migrate_tools.run_popen_cmd(cmd))
     except Exception as e:
         exit_with_msg('Failed to locate or read the oci config file, is oci '
@@ -114,21 +129,23 @@ def main():
     # namespace
     cmd = ['oci', 'os', 'ns', 'get']
     try:
+        if verboseflag:
+            console_msg(msg='Running: %s' % cmd)
         nsdict = json.loads(migrate_tools.run_popen_cmd(cmd))
         namespace = nsdict['data']
-        console_msg(msg='namespace: %s' % namespace)
+        console_msg(msg='Namespace: %s' % namespace)
     except Exception as e:
-        exit_with_message('Failed to identify the namespace: %s' % str(e))
+        exit_with_msg('Failed to identify the namespace: %s' % str(e))
     #
     # compartment
     try:
         foundcom = False
-        for k,v in cmpdict.items():
+        for k, v in cmpdict.items():
             for x in v:
                 if x['name'] == compartment:
                     compdata = x
                     # print(compdata)
-                    console_msg(msg='compartment data: %s' % compdata['id'])
+                    console_msg(msg='Compartment data: %s' % compdata['id'])
                     compartment_id = compdata['id']
                     foundcom = True
                     break
@@ -140,38 +157,45 @@ def main():
     # bucket
     try:
         bucketcontents = migrate_utils.bucket_exists(bucket)
-        console_msg(msg='Object storage %s present.' % bucket)
+        if verboseflag:
+            console_msg(msg='Object storage %s present.' % bucket)
     except Exception as e:
         exit_with_msg('Object storage %s not found: %s' % (bucket, str(e)))
     #
     # bucket data
     try:
         cmd = ['oci', 'os', 'bucket', 'get', '--bucket-name', '%s' % bucket]
-        console_msg(msg='running: %s' % cmd)
+        if verboseflag:
+            console_msg(msg='Running: %s' % cmd)
         bucketlist = migrate_tools.run_popen_cmd(cmd)
         if bucketlist is not None:
             bucketdict = json.loads(bucketlist)
+            _logger.debug('Object storage data: %s' % bucketdict)
         else:
-            console_msg(msg='bucket data for %s is empty.' % bucket)
+            if verboseflag:
+                console_msg(msg='Bucket data for %s is empty.' % bucket)
     except Exception as e:
         exit_with_msg('Failed to get data of %s: %s' % (bucket, str(e)))
     #
     # bucket contents
     try:
-        cmd = ['oci', 'os', 'object', 'list', '--bucket-name', '%s' %  bucket]
-        console_msg('running: %s' % cmd)
+        cmd = ['oci', 'os', 'object', 'list', '--bucket-name', '%s' % bucket]
+        if verboseflag:
+            console_msg('Running: %s' % cmd)
         bucketcontents = migrate_tools.run_popen_cmd(cmd)
         if bucketcontents is not None:
             bucketcontentsdict = json.loads(bucketcontents)
+            _logger.debug(('Object storage contents: %s' % bucketcontentsdict))
         else:
-            console_msg(msg='bucket %s is emtpy.' % bucket)
-        #print('%s' % bucketcontentsdict)
+            if verboseflag:
+                console_msg(msg='Bucket %s is emtpy.' % bucket)
     except Exception as e:
-        exit_with_msg('Failed to get contents of %s: %s' % (bucket, str(e)))    
-    #
+        exit_with_msg('Failed to get contents of %s: %s' % (bucket, str(e)))
+        #
     # object exists?
     if migrate_utils.object_exists(bucketcontents, objectname):
-        console_msg(msg='Object %s present in %s.' % (objectname, bucket))
+        if verboseflag:
+            console_msg(msg='Object %s present in %s.' % (objectname, bucket))
     else:
         exit_with_msg('Object %s missing from %s.' % (objectname, bucket))
     #
@@ -179,9 +203,16 @@ def main():
     cmd = ['oci', 'compute', 'image', 'list', '--compartment-id',
            '%s' % compartment_id, '--display-name',
            '%s' % displayname]
+    if verboseflag:
+        console_msg('Running: %s' % cmd)
     objstat = migrate_tools.run_popen_cmd(cmd)
     if objstat is not None:
         exit_with_msg('Image with name %s already exists.' % displayname)
+    else:
+        if verboseflag:
+            console_msg('Image with name %s not yet imported.' % displayname)
+        else:
+            _logger.debug('Image with name %s not yet imported.' % displayname)
     #
     # upload?
     if not read_yn('\n  Uploading %s to %s as %s'
@@ -190,50 +221,35 @@ def main():
     cmd = ['oci', 'compute', 'image', 'import', 'from-object', '--bucket-name',
            '%s' % bucket, '--compartment-id', '%s' % compartment_id,
            '--name', '%s' % objectname, '--namespace', '%s' % namespace,
-           '--launch-mode',  launchmode, '--display-name', '%s' % displayname]
-    console_msg(msg='running: %s' % cmd)
+           '--launch-mode', launchmode, '--display-name', '%s' % displayname]
+    if verboseflag:
+        console_msg(msg='Running: %s' % cmd)
     try:
         resval = migrate_tools.run_popen_cmd(cmd)
-        #console_msg(msg='running import: %s' % resval)
     except Exception as e:
         exit_with_msg('Failed to import %s: %s' % (objectname, str(e)))
     #
     # follow up
     cmd = ['oci', 'compute', 'image', 'list', '--compartment-id',
            '%s' % compartment_id, '--display-name', '%s' % displayname]
-    # console_msg(msg='running: %s' % cmd)
     finished = False
-    year, month, day, hour, min = map(int, time.strftime("%Y %m %d %H %M").split())
-    sys.stdout.write('\n  %02d-%02d-%04d %02d:%02d %s\n'
-                     % (day, month, year, hour, min,
-                        'Starting import of %s' % displayname))
-    sys.stdout.flush()
-    cnt=0
-    modcnt=40
-    addn = -1
+    _, clmns = os.popen('stty size', 'r').read().split()
+    importwait = migrate_tools.ProgressBar(int(clmns), 0.2,
+                                           progress_chars=['importing %s' %
+                                                           displayname])
+    importwait.start()
     while not finished:
         objstat = json.loads(migrate_tools.run_popen_cmd(cmd))
         for ob in objstat['data']:
             if ob['display-name'] == displayname:
                 if ob['lifecycle-state'] == 'AVAILABLE':
                     finished = True
-                else:
-                    addn *= -1
-                    for i in range(modcnt-1):
-                        cntstr = (cnt%modcnt+1)*'.' + (modcnt-cnt%modcnt)*' '
-                        year, month, day, hour, min \
-                            = map(int, time.strftime("%Y %m %d %H %M").split())
-                        sys.stdout.write('  %02d-%02d-%04d %02d:%02d %s %s\r'
-                                         % (day, month, year, hour, min,
-                                            'Still importing %s' % displayname, cntstr))
-                        sys.stdout.flush()
-                        time.sleep(1)
-                        cnt += 1
             else:
                 console_msg(msg='%s not found.' % displayname)
+    if migrate_tools.isthreadrunning(importwait):
+        importwait.stop()
     console_msg(msg='Done')
-
-    return(0)
+    return 0
 
 
 if __name__ == "__main__":

--- a/lib/oci_utils/impl/oci-image-migrate-import.py
+++ b/lib/oci_utils/impl/oci-image-migrate-import.py
@@ -1,0 +1,240 @@
+# oci-utils
+#
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Script to import an on-premise virtual server from an object storage to the custom images 
+in the Oracle Cloud Infrastructure. An image which passed the checks and modifications 
+of - and was uploaded by the oci-image-migrate utility should import fine.
+"""
+import argparse
+import json
+import logging.config
+import six
+import sys
+import time
+
+from oci_utils.migrate import console_msg, exit_with_msg, read_yn
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate import migrate_utils
+
+_logger = logging.getLogger('oci-utils.import_ci')
+
+
+def parse_args():
+    """
+    Parse the command line arguments and return an object representing the command
+    line as returned by the argparse's parse-args().
+    arguments:
+    -i|--image-name <image name>; mandatory.
+    -b|--bucket-name <bucket name>; mandatdory.
+    -c|--compartment-name <compartment name>; mandatory.
+    -l|--launch-mode [PARAVIRTUALIZED|EMULATED|NATIVE]; optional, the default
+         is PARAVIRTUALIZED.
+    -d|--displayname <display name>; optional.
+    
+    Returns
+    -------
+        The command line namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description='Utility to import a (verified and modified) on-premise '
+                    'legacy images which was uploaded to object storage in '
+                    'the custom images folderof the Oracle Cloud Infrastructure.',
+        add_help=False)
+    #
+    parser.add_argument('-i', '--image-name',
+                        action='store',
+                        dest='imagename',
+                        required=True,
+                        help='The name of the object representing the uploaded image.')
+    parser.add_argument('-b', '--bucket-name',
+                        action='store',
+                        dest='bucketname',
+                        required=True,
+                        help='The name of the object storage.')
+    parser.add_argument('-c', '--compartment-name',
+                        action='store',
+                        dest='compartmentname',
+                        required=True,
+                        help='The name of the destination compartment.')
+    parser.add_argument('-d', '--display-name',
+                        action='store',
+                        dest='displayname',
+                        help='Image name as it will show up in the custom '
+                             'images; the default is the image name.',
+                        default=None)
+    parser.add_argument('-l', '--launch-mode',
+                        action='store',
+                        dest='launchmode',
+                        help='The mode the instance created from the custom '
+                             'image will be started; the default '
+                             'is PARAVIRTUALIZED.',
+                        choices=['PARAVIRTUALIZED', 'EMULATED', 'NATIVE'],
+                        default='PARAVIRTUALIZED')
+    parser.add_argument('--help', action='help', help='Display this help')
+    parser._optionals.title = 'Arguments'
+    args = parser.parse_args()
+    if args.displayname is None:
+        args.displayname = args.imagename
+    return args
+
+def main():
+    #
+    # command line
+    cmdlineargs = parse_args()
+    console_msg(msg = 'Importing %s from %s into %s as %s and setting '
+                      'launchmode to %s.' % (cmdlineargs.imagename,
+                                             cmdlineargs.bucketname,
+                                             cmdlineargs.bucketname,
+                                             cmdlineargs.displayname,
+                                             cmdlineargs.launchmode))
+    compartment = cmdlineargs.compartmentname
+    bucket = cmdlineargs.bucketname
+    objectname = cmdlineargs.imagename
+    displayname = cmdlineargs.displayname
+    launchmode = cmdlineargs.launchmode
+    #
+    # oci config file 
+    try:
+        ocicfg = migrate_utils.get_oci_config()
+        console_msg('Found oci config file')
+        tenancy = ocicfg['tenancy']
+        console_msg(msg = 'tenancy = %s' % tenancy)
+        _logger.debug('Tenancy: %s' % tenancy)
+        cmd = ['oci', 'iam', 'compartment', 'list', '-c', '%s' % tenancy, '--all']
+        console_msg(msg='running: %s' % cmd)
+        cmpdict = json.loads(migrate_tools.run_popen_cmd(cmd))
+    except Exception as e:
+        exit_with_msg('Failed to locate or read the oci config file, is oci '
+                      'cli installed?: %s' % str(e))
+    #
+    # namespace
+    cmd = ['oci', 'os', 'ns', 'get']
+    try:
+        nsdict = json.loads(migrate_tools.run_popen_cmd(cmd))
+        namespace = nsdict['data']
+        console_msg(msg='namespace: %s' % namespace)
+    except Exception as e:
+        exit_with_message('Failed to identify the namespace: %s' % str(e))
+    #
+    # compartment
+    try:
+        foundcom = False
+        for k,v in cmpdict.items():
+            for x in v:
+                if x['name'] == compartment:
+                    compdata = x
+                    # print(compdata)
+                    console_msg(msg='compartment data: %s' % compdata['id'])
+                    compartment_id = compdata['id']
+                    foundcom = True
+                    break
+        if not foundcom:
+            exit_with_msg('Failed to find %s' % compartment)
+    except Exception as e:
+        exit_with_msg('Failed to find %s: %s' % (compartment, str(e)))
+    #
+    # bucket
+    try:
+        bucketcontents = migrate_utils.bucket_exists(bucket)
+        console_msg(msg='Object storage %s present.' % bucket)
+    except Exception as e:
+        exit_with_msg('Object storage %s not found: %s' % (bucket, str(e)))
+    #
+    # bucket data
+    try:
+        cmd = ['oci', 'os', 'bucket', 'get', '--bucket-name', '%s' % bucket]
+        console_msg(msg='running: %s' % cmd)
+        bucketlist = migrate_tools.run_popen_cmd(cmd)
+        if bucketlist is not None:
+            bucketdict = json.loads(bucketlist)
+        else:
+            console_msg(msg='bucket data for %s is empty.' % bucket)
+    except Exception as e:
+        exit_with_msg('Failed to get data of %s: %s' % (bucket, str(e)))
+    #
+    # bucket contents
+    try:
+        cmd = ['oci', 'os', 'object', 'list', '--bucket-name', '%s' %  bucket]
+        console_msg('running: %s' % cmd)
+        bucketcontents = migrate_tools.run_popen_cmd(cmd)
+        if bucketcontents is not None:
+            bucketcontentsdict = json.loads(bucketcontents)
+        else:
+            console_msg(msg='bucket %s is emtpy.' % bucket)
+        #print('%s' % bucketcontentsdict)
+    except Exception as e:
+        exit_with_msg('Failed to get contents of %s: %s' % (bucket, str(e)))    
+    #
+    # object exists?
+    if migrate_utils.object_exists(bucketcontents, objectname):
+        console_msg(msg='Object %s present in %s.' % (objectname, bucket))
+    else:
+        exit_with_msg('Object %s missing from %s.' % (objectname, bucket))
+    #
+    # display name exists?
+    cmd = ['oci', 'compute', 'image', 'list', '--compartment-id',
+           '%s' % compartment_id, '--display-name',
+           '%s' % displayname]
+    objstat = migrate_tools.run_popen_cmd(cmd)
+    if objstat is not None:
+        exit_with_msg('Image with name %s already exists.' % displayname)
+    #
+    # upload?
+    if not read_yn('\n  Uploading %s to %s as %s'
+                   % (objectname, compartment, displayname)):
+        exit_with_msg('Exiting.\n')
+    cmd = ['oci', 'compute', 'image', 'import', 'from-object', '--bucket-name',
+           '%s' % bucket, '--compartment-id', '%s' % compartment_id,
+           '--name', '%s' % objectname, '--namespace', '%s' % namespace,
+           '--launch-mode',  launchmode, '--display-name', '%s' % displayname]
+    console_msg(msg='running: %s' % cmd)
+    try:
+        resval = migrate_tools.run_popen_cmd(cmd)
+        #console_msg(msg='running import: %s' % resval)
+    except Exception as e:
+        exit_with_msg('Failed to import %s: %s' % (objectname, str(e)))
+    #
+    # follow up
+    cmd = ['oci', 'compute', 'image', 'list', '--compartment-id',
+           '%s' % compartment_id, '--display-name', '%s' % displayname]
+    # console_msg(msg='running: %s' % cmd)
+    finished = False
+    year, month, day, hour, min = map(int, time.strftime("%Y %m %d %H %M").split())
+    sys.stdout.write('\n  %02d-%02d-%04d %02d:%02d %s\n'
+                     % (day, month, year, hour, min,
+                        'Starting import of %s' % displayname))
+    sys.stdout.flush()
+    cnt=0
+    modcnt=40
+    addn = -1
+    while not finished:
+        objstat = json.loads(migrate_tools.run_popen_cmd(cmd))
+        for ob in objstat['data']:
+            if ob['display-name'] == displayname:
+                if ob['lifecycle-state'] == 'AVAILABLE':
+                    finished = True
+                else:
+                    addn *= -1
+                    for i in range(modcnt-1):
+                        cntstr = (cnt%modcnt+1)*'.' + (modcnt-cnt%modcnt)*' '
+                        year, month, day, hour, min \
+                            = map(int, time.strftime("%Y %m %d %H %M").split())
+                        sys.stdout.write('  %02d-%02d-%04d %02d:%02d %s %s\r'
+                                         % (day, month, year, hour, min,
+                                            'Still importing %s' % displayname, cntstr))
+                        sys.stdout.flush()
+                        time.sleep(1)
+                        cnt += 1
+            else:
+                console_msg(msg='%s not found.' % displayname)
+    console_msg(msg='Done')
+
+    return(0)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/oci_utils/impl/oci-image-migrate-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-main.py
@@ -9,7 +9,7 @@
 """
 Script to migrate on-premise virtual servers to the Oracle Cloud
 Infrastructure. The candidate image needs to comply with:
-- BIOS boot;
+- BIOS or UEFI boot;
 - image size is maximum 300GB;
 - contain one disk containing Master Boot Record and boot loader;
 - no additional volumes are required to complete the boot process;
@@ -372,7 +372,7 @@ def main():
     # More on command line arguments.
     #
     # initialise output
-    migrate_tools.result_msg(msg='\n  Results are written to %s.' % resultfilename,
+    migrate_tools.result_msg(msg='Results are written to %s.' % resultfilename,
                          result=True)
     migrate_tools.result_msg(msg='Input image:  %s' % imagepath, result=True)
     #
@@ -452,13 +452,25 @@ def main():
             prereq_msg += msg
         #
         if imgres:
-            prereq_msg += '\n\n  + %s data collection and processing succeeded.' \
+            prereq_msg += '\n\n  %s data collection and processing succeeded.' \
                       % imagepath
         else:
             prereq_passed = False
         #
         if prereq_passed:
             migrate_tools.result_msg(msg=prereq_msg, result=True)
+            if imagedata['boot_type'] == 'BIOS':
+                migrate_tools.result_msg(msg='Boot type is BIOS, '
+                                             'use launch_mode PARAVIRTUALIZED '
+                                             '(or EMULATED) at import.',
+                                         result = True)
+            elif imagedata['boot_type'] == 'UEFI':
+                migrate_tools.result_msg(msg='Boot type is UEFI, '
+                                             'use launch_mode NATIVE at '
+                                             'import.', result=True)
+            else:
+                exit_with_msg('*** ERROR *** Something wrong checking the '
+                              'boot type')
         else:
             prereq_msg += '\n\n  + %s processing failed, check the logfile ' \
                           'and/or set environment variable _OCI_UTILS_DEBUG.' \

--- a/lib/oci_utils/impl/oci-image-migrate-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-main.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
-
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 

--- a/lib/oci_utils/impl/oci-image-migrate-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-main.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python
+
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Script to migrate on-premise virtual servers to the Oracle Cloud
+Infrastructure. The candidate image needs to comply with:
+- BIOS boot;
+- image size is maximum 300GB;
+- contain one disk containing Master Boot Record and boot loader;
+- no additional volumes are required to complete the boot process;
+- the boot and root partitions are not encrypted;
+- the image is a single file in VMDK or QCOW2 format;
+- the boot loader uses UUID or LVM to locate the boot volume;
+- the network configuration does not contain hardcoded MAC addresses;
+"""
+
+import argparse
+import importlib
+import logging.config
+import os
+import pkgutil
+import sys
+import time
+
+from oci_utils.migrate import exit_with_msg, get_config_data, pause_msg, read_yn
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate import migrate_utils
+from oci_utils.migrate.exception import OciMigrateException
+
+try:
+    import yaml
+except ImportError as e:
+    exit_with_msg('oci-image-migrate needs yaml module in order to load '
+                  'configuration data and to analyse certain network '
+                  'configuration files. Install it using the package manager '
+                  '(python-yaml) or via pip (pip[|2|3] install yaml.)')
+    raise OciMigrateException('Failed to find the yaml module.')
+try:
+    from setuptools import setup, find_packages
+except ImportError:
+    print("oci-utils needs setuptools in order to build. Install it using "
+          "your package manager (usually python-setuptools) or via pip (pip "
+          "install setuptools).")
+    sys.exit(1)
+
+_logger = logging.getLogger('oci-utils.oci-image-migrate')
+
+#
+# Dictionary containing utilities which might be needed with the packages
+# which provide them.
+try:
+    helpers_list = get_config_data('helpers_list')
+except Exception as e:
+    exit_with_msg('Failed to retrieve the list of required utilities. Verify '
+                  'the existence and contents of the configuration file '
+                  'oci-migrate-conf.yaml.')
+
+
+def parse_args():
+    """
+    Parse the command line arguments and return an object representing the
+    command line (as returned by argparse's parse_args())
+    arguments:
+     -i|--input-image <on-premise image>; mandatory.
+     -b|--bucket <bucket name>; mandatory.
+     -o|--output-image <output image name>; optional.
+     -v|--verbose produces verbose output.
+     -h|--help
+
+    Returns
+    -------
+        The command line namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description='Utility to support preparation of on-premise legacy '
+                    'images for importing in the Oracle Cloud Infrastructure.',
+        add_help=False)
+    #
+    parser.add_argument('-i', '--input-image',
+                        action='store',
+                        dest='inputimage',
+                        type=argparse.FileType('r'),
+                        required=True,
+                        help='The on-premise image for migration to OCI.')
+    parser.add_argument('-b', '--bucket',
+                        action='store',
+                        dest='bucketname',
+                        required=True,
+                        help='The destination bucket in OCI to store '
+                             'the converted image.')
+    parser.add_argument('-o', '--output-image',
+                        action='store',
+                        dest='outputimage',
+                        help='The output image name.')
+    parser.add_argument('--verbose', '-v',
+                        action='store_true',
+                        dest='verboseflag',
+                        default=False,
+                        help='Show verbose information.')
+    parser.add_argument('--help',
+                        action='help',
+                        help='Display this help')
+    parser._optionals.title = 'Arguments'
+
+    args = parser.parse_args()
+    return args
+
+
+def import_formats():
+    """
+    Import modules which handle different image formats and construct the
+    format data dictionary. Check the object definitions for the
+    'format_data' attribute.
+
+    Returns
+    -------
+        dict: Dictionary containing for each image format at least:
+              { magic number : { name : <type name>,
+                                 module : <module name>,
+                                 clazz : <the class name>,
+                                 prereq : <prequisites dictionary>
+                                }
+              }
+    """
+    attr_format = 'format_data'
+    imagetypes = dict()
+    packagename = 'oci_utils.migrate'
+    pkg = __import__(packagename)
+    _logger.debug('pkg name: %s' % pkg)
+    path = os.path.dirname(sys.modules.get(packagename).__file__)
+    _logger.debug('path: %s' % path)
+    #
+    # loop through modules in path, look for the attribute 'format_data' which
+    # defines the basics of the image type, i.e. the magic number, the name and
+    # essentially the class name and eventually prequisites.
+    for _, module_name, _ in pkgutil.iter_modules([path]):
+        type_name = packagename + '.' + module_name
+        _logger.debug('type_name: %s' % type_name)
+        try:
+            impret = importlib.import_module(type_name)
+            _logger.debug('import result: %s' % impret)
+            attrret = getattr(sys.modules[type_name], attr_format)
+            _logger.debug('attribute format_data: %s' % attrret)
+            for key in attrret:
+                if key != get_config_data('dummy_format_key'):
+                    imagetypes.update(attrret)
+                else:
+                    _logger.debug('%s is the dummy key, skipping.' % key)
+        except Exception as e:
+            _logger.debug('attribute %s not found in %s: %s'
+                         % (attr_format, type_name, str(e)))
+    return imagetypes
+
+
+def show_utilities(found, missing):
+    """
+    Display the status of the required utilities.
+
+    Parameters
+    ----------
+    found: list
+        List of found utilities.
+    missing: list
+        List of missing utilities.
+
+    Returns
+    -------
+        No return value.
+    """
+    if found:
+        print('\n  %30s\n%s' % ('  Utilities found:', '  ' + '-'*60))
+        for util in found:
+            print('  %30s' % util)
+    if missing:
+        print('\n  %30s\n%s' % ('  Utilities not found:', '  ' + '-'*60))
+        for util in missing:
+            print('  %30s, needs package %s' % (util, helpers_list[util]))
+    print('\n')
+
+
+def show_supported_formats_data(thisdict):
+    """
+    Display the data collected from the image type modules.
+
+    Parameters
+    ----------
+    thisdict: dict
+        Data about the supported image types.
+
+    Returns
+    -------
+        No return value.
+    """
+    print('\n  %25s\n  %25s\n  %25s : %-20s\n  %25s   %-20s'
+          % ('Supported image formats', '-'*25,
+             'Magic Key', 'Format data', '-'*20, '-'*20))
+    for key in sorted(thisdict):
+        print('  %25s : ' % key)
+        thissubdict = thisdict[key]
+        for yek in sorted(thissubdict):
+            print('  %35s : %s' % (yek, thissubdict[yek]))
+        print('\n')
+
+
+def collect_image_data(imgobject):
+    """
+    Verify the prerequisites of the image file with respect to the migration
+    to the Oracle Cloud Infrastructure.
+
+    Parameters
+    ----------
+    imgobject: Qcow2Head, VmdkHead, SomeTypeHead..  object
+        The image object.
+
+    Returns
+    -------
+        dict:
+            The image data.
+    """
+    try:
+        res, img_info = imgobject.image_data()
+    except Exception as e:
+        _logger.critical('Unable to collect or invalid image data: %s'
+                        % str(e), exc_info=True)
+        raise OciMigrateException('Unable to collect or invalid image data: %s'
+                                  % str(e))
+    # need to return the img_info object in the end...
+    return res, img_info
+
+
+def test_helpers():
+    """
+    Verify which utilities are available.
+
+    Returns
+    -------
+        helpers: List of available utilities.
+        missing: List of missing utilities.
+    """
+    helpers = []
+    missing = []
+    thispath = os.getenv('PATH')
+    _logger.debug('PATH is %s' % thispath)
+    for util in helpers_list:
+        cmd = ['which', util]
+        try:
+            ocipath = migrate_tools.run_popen_cmd(cmd)
+            _logger.debug('%s path is %s' % (util, ocipath))
+        except Exception as e:
+            _logger.error('Cannot find %s anymore: %s' % (util, str(e)),
+                         exc_info=True)
+
+        try:
+            _logger.debug('Availability of %s' % util)
+            fullcmd = migrate_tools.exec_exists(util)
+            _logger.debug('full path: %s' % fullcmd)
+            if migrate_tools.exec_exists(util):
+                helpers.append(util)
+            else:
+                missing.append(util)
+        except Exception as e:
+            _logger.error('utility %s is not installed: %s'
+                         % (helpers_list[util], str(e)))
+    return helpers, missing
+
+
+def main():
+    """
+    Main
+
+    Returns
+    -------
+        int
+            0 on success, 1 otherwise.
+    """
+    pythonver = sys.version_info[0]
+    args = parse_args()
+    #
+    _logger.debug('Python version is %s' % pythonver)
+    #
+    # Verbose mode is False by default
+    verboseflag = args.verboseflag
+    migrate_tools.verboseflag = verboseflag
+    _logger.debug('Verbose level set to %s' % verboseflag)
+    #
+    # Operator needs to be root.
+    if migrate_tools.is_root():
+        migrate_tools.result_msg(msg='User is root.')
+    else:
+        exit_with_msg('  *** ERROR *** %s needs to be run as root user'
+                      % sys.argv[0])
+    try:
+        #
+        # input image
+        if args.inputimage:
+            imagepath = args.inputimage.name
+            resultfilename = get_config_data('resultfilepath') \
+                             + '_' \
+                             + os.path.splitext(os.path.basename(imagepath))[0]  \
+                            + '.res'
+            migrate_tools.resultfilename = resultfilename
+            migrate_tools.result_msg(msg='\n  Running %s at %s\n'
+                                 % (' '.join(sys.argv), time.ctime()),
+                                 flags='wb', result=True)
+        else:
+            raise OciMigrateException('Missing argument: input image path.')
+        #
+        # Import the 'format' modules and collect the format data
+        supported_formats = import_formats()
+        if verboseflag:
+            show_supported_formats_data(supported_formats)
+        #
+        # Check the utilities installed.
+        util_list, missing_list = test_helpers()
+        _logger.debug('%s' % util_list)
+        if verboseflag:
+            show_utilities(util_list, missing_list)
+        if missing_list:
+            raise OciMigrateException('%s needs packages %s installed.\n' % (sys.argv[0],
+                                                          missing_list), 1)
+        #
+        # Check if oci-cli is configured.
+        if migrate_tools.file_exists(get_config_data('ociconfigfile')):
+            migrate_tools.result_msg(msg='oci-cli config file exists.')
+        else:
+            raise OciMigrateException('oci-cli is not configured.')
+        #
+        # Get the nameserver definition
+        if migrate_tools.get_nameserver():
+            _logger.debug('Nameserver identified as %s' % migrate_tools.nameserver)
+        else:
+            migrate_tools.error_msg('Failed to identify nameserver, using %s, '
+                               'but might cause issues.' % migrate_tools.nameserver)
+        #
+        # bucket
+        bucketname = args.bucketname
+        migrate_tools.result_msg(msg='Bucket name:  %s' % bucketname, result=True)
+        #
+        # Verify if object storage exits.
+        try:
+            thisbucket = migrate_utils.bucket_exists(bucketname)
+            migrate_tools.result_msg(msg='Object storage %s exists.' % bucketname,
+                                 result=True)
+        except Exception as e:
+            raise OciMigrateException(str(e))
+        #
+        # output image
+        if args.outputimage:
+            outputname = args.outputimage
+        else:
+            outputname = os.path.splitext(os.path.basename(imagepath))[0]
+        migrate_tools.result_msg(msg='Output name:  %s\n' % outputname, result=True)
+        #
+        # bucket
+        bucketname = args.bucketname
+        migrate_tools.result_msg(msg='Bucket name:  %s' % bucketname, result=True)
+        #
+        # Verify if object already exists.
+        if migrate_utils.object_exists(thisbucket, outputname):
+            raise OciMigrateException('Object %s already exists in object '
+                                      'storage %s.' % (outputname, bucketname))
+        else:
+            _logger.debug('Object %s does not yet exists in object storage %s' % (outputname, bucketname))
+    except Exception as e:
+        exit_with_msg('  *** ERROR *** %s\n' % str(e))
+    #
+    # More on command line arguments.
+    #
+    # initialise output
+    migrate_tools.result_msg(msg='\n  Results are written to %s.' % resultfilename,
+                         result=True)
+    migrate_tools.result_msg(msg='Input image:  %s' % imagepath, result=True)
+    #
+    # output image
+    if args.outputimage:
+        outputname = args.outputimage
+    else:
+        outputname = os.path.splitext(os.path.basename(imagepath))[0]
+    migrate_tools.result_msg(msg='Output name:  %s\n' % outputname, result=True)
+    #
+    # Verify if readable.
+    fn_magic = migrate_tools.get_magic_data(imagepath)
+    if fn_magic is None:
+        exit_with_msg('*** ERROR *** An error occured while trying to read magic '
+                           'number of File %s.' % imagepath)
+    else:
+        pause_msg('Image Magic Number: %s' % fn_magic)
+        _logger.debug('Magic number %s successfully read' % fn_magic)
+    #
+    # Verify if image type is supported.
+    _logger.debug('Magic number of %s is %s' % (imagepath, fn_magic))
+    if fn_magic not in supported_formats:
+        exit_with_msg('*** ERROR *** Image type %s is not recognised.' % fn_magic)
+    else:
+        _logger.debug('Image type recognised.')
+    #
+    # Get the correct class.
+    imageclazz = supported_formats[fn_magic]
+    migrate_tools.result_msg(msg='Type of image %s identified as %s'
+                             % (imagepath, imageclazz['name']), result=True)
+    pause_msg('Image type is %s' % imageclazz['name'])
+    #
+    # Locate the class and module
+    imageclassdef = getattr(sys.modules['oci_utils.migrate.%s'
+                                        % supported_formats[fn_magic]['name']],
+                            imageclazz['clazz'])
+    imageobject = imageclassdef(imagepath)
+    #
+    # Generic data collection
+    try:
+        imgres, imagedata = collect_image_data(imageobject)
+        if verboseflag:
+            migrate_utils.show_image_data(imageobject)
+        if imgres:
+            _logger.debug('Image processing succeeded.')
+        else:
+            _logger.critical('Image processing failed.', exc_info=True)
+        #
+        if imagedata:
+            _logger.debug('%s passed verification.' % imagepath)
+        else:
+            _logger.critical('%s failed image check.' % imagepath, exc_info=True)
+    except Exception as e:
+        _logger.critical('%s failed image check: %s' % (imagepath, str(e)))
+        exit_with_msg('*** ERROR *** Problem detected during investigation of '
+                      'the image %s: %s, exiting.' % (imagepath, str(e)))
+    #
+    # passed prerequisites and changes?
+    prereq_passed = True
+    #
+    # Image type specific prerequisites
+    prereq_msg = ''
+    sup, msg = imageobject.type_specific_prereq_test()
+    if sup:
+        migrate_tools.result_msg(msg='%s' % msg, result=True)
+    else:
+        prereq_passed = False
+        prereq_msg = msg
+    #
+    # Generic prerequisites verification
+    try:
+        gen_prereq, msg = imageobject.generic_prereq_check()
+        if gen_prereq:
+            prereq_msg += '\n  %s passed the generic preqrequisites.' % imagepath
+        else:
+            prereq_passed = False
+            prereq_msg += msg
+        #
+        if imgres:
+            prereq_msg += '\n\n  + %s data collection and processing succeeded.' \
+                      % imagepath
+        else:
+            prereq_passed = False
+        #
+        if prereq_passed:
+            migrate_tools.result_msg(msg=prereq_msg, result=True)
+        else:
+            prereq_msg += '\n\n  + %s processing failed, check the logfile ' \
+                          'and/or set environment variable _OCI_UTILS_DEBUG.' \
+                          % imagepath
+            raise OciMigrateException(prereq_msg)
+    except Exception as e:
+        exit_with_msg('*** ERROR ***  %s' % str(e))
+    #
+    # While prerequisite check did not hit a fatal issue, there might be
+    # situations where upload should not proceed.
+    if not migrate_tools.migrate_preparation:
+        exit_with_msg('*** ERROR *** Unable to proceed with uploading image '
+                      'to Oracle Cloud Infrastructure: %s'
+                      % migrate_tools.migrate_non_upload_reason)
+    #
+    # Ask for agreement to proceed.
+    if not read_yn('\n  Agree to proceed uploading %s to %s as %s?'
+                   % (imagepath, bucketname, outputname)):
+        exit_with_msg('\n  Exiting.')
+    #
+    # Prerequisite verification and essential image updates passed, uploading
+    # image.
+    try:
+        uploadprogress = migrate_tools.ProgressBar(1, 0.5)
+        #
+        # Verify if object already exists.
+        if migrate_utils.object_exists(thisbucket, outputname):
+            raise OciMigrateException('Object %s already exists object '
+                                      'storage %s.' % (outputname, bucketname))
+        else:
+            _logger.debug('Object %s does not yet exists in object storage %s'
+                         % (outputname, bucketname))
+        #
+        # Upload the image.
+        migrate_tools.result_msg(msg='\n  Uploading %s, this might take a while....'
+                                 % imagepath, result=True)
+        uploadprogress.start()
+        uploadres = migrate_utils.upload_image(imagepath, bucketname,
+                                               outputname)
+        _logger.debug('Uploadresult: %s' % uploadres)
+        migrate_tools.result_msg(msg='  Finished....\n', result=True)
+        uploadprogress.stop()
+    except Exception as e:
+        _logger.error('Error while uploading %s to %s: %s.'
+                     % (imagepath, bucketname, str(e)))
+        exit_with_msg('*** ERROR *** Error while uploading %s to %s: %s.'
+                      % (imagepath, bucketname, str(e)))
+    finally:
+        #
+        # if progressthread was started, needs to be terminated.
+        if migrate_tools.isthreadrunning(uploadprogress):
+            uploadprogress.stop()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/oci_utils/impl/sudo_utils.py
+++ b/lib/oci_utils/impl/sudo_utils.py
@@ -19,7 +19,7 @@ _logger = logging.getLogger('oci-utils.sudo')
 
 def _prepare_command(cmd):
     """
-    Prepare the command line to be executed prepend sudo if not alreary present.
+    Prepare the command line to be executed prepend sudo if not already present.
 
     Parameters
     ----------
@@ -130,7 +130,7 @@ def call_popen_output(cmd, log_output=True):
         return 404
     except subprocess.CalledProcessError as e:
         if log_output:
-            _logger.debug("Error execeuting {}: {}\n{}\n"
+            _logger.debug("Error executing {}: {}\n{}\n"
                           .format(_c, e.returncode, e.output))
         return None
 

--- a/lib/oci_utils/impl/sudo_utils.py
+++ b/lib/oci_utils/impl/sudo_utils.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 

--- a/lib/oci_utils/migrate/__init__.py
+++ b/lib/oci_utils/migrate/__init__.py
@@ -1,0 +1,174 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+import os
+import sys
+import termios
+import tty
+import yaml
+
+from oci_utils.migrate.exception import OciMigrateException
+
+__ocimigrateconffile = '/etc/oci-utils/oci-migrate-conf.yaml'
+
+
+def _getch():
+    """
+    Read a single keypress from stdin.
+
+    Returns
+    -------
+        The resulting character.
+    """
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    return ch
+
+
+def read_yn(prompt, yn=True):
+    """
+    Read yes or no form stdin, No being the default.
+
+    Parameters
+    ----------
+        prompt: str
+            The message.
+        yn: bool
+            Add (y/N) to the prompt if True.
+    Returns
+    -------
+        bool: True on yes, False otherwise.
+    """
+    thisprmpt = prompt + ' '
+    if yn:
+        thisprmpt += ' (y/N) '
+    sys.stdout.write(thisprmpt)
+    yn = _getch()
+    sys.stdout.write('\n')
+    if yn.upper() == 'Y':
+        return True
+    else:
+        return False
+
+
+def exit_with_msg(msg, exitcode=1):
+    """
+    Post a message on stdout and exit.
+
+    Parameters
+    ----------
+    msg: str
+        The exit message.
+    exitcode: int
+        The exit code, default is 1.
+
+    Returns
+    -------
+        No return value.
+    """
+    sys.stderr.write('\n  %s\n' % msg)
+    exit(exitcode)
+
+
+def pause_msg(msg=None):
+    """
+    Pause function.
+
+    Parameters:
+    ----------
+    msg: str
+        Eventual pause message.
+
+    Returns
+    -------
+        No return value.
+    """
+    if os.environ.get('OCIPAUSE'):
+        ban0 = '\n  Press a key to continue'
+        if msg is not None:
+            ban0 = '\n  %s' % msg + ban0
+        _ = read_yn(ban0, False)
+
+
+def console_msg(msg=None):
+    """
+    Writes a message to the console.
+
+    Parameters:
+    ----------
+        msg: str
+            The message
+    Returns:
+    -------
+         No return value.
+    """
+    if msg is None:
+        msg = 'Notification.'
+    sys.stdout.write('\n  %s\n' % msg)
+
+
+class OciMigrateConfParam(object):
+    """
+    Retrieve oci-image-migrate configuration data from the
+    oci-image-migrate configuration file, in yaml format.
+    """
+    def __init__(self, yamlconf, tag):
+        """
+        Initialisation of the oci image migrate configuration retrieval.
+
+        Parameters:
+        ----------
+            yamlconf: str
+                The full path of the oci-image-migrate configuration file.
+            tag: str
+                The configuration structure to collect.
+        """
+        self._yc = yamlconf
+        self._tg = tag
+
+    def __enter__(self):
+        """
+        OciMigrateConfParam entry.
+        """
+        with open(self._yc, 'r') as f:
+            self.confdata = yaml.load(f, Loader=yaml.SafeLoader)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        OciMigrateConfParam cleanup and exit.
+        """
+        pass
+
+    def values(self):
+        """
+        Retrieve the configuration data.
+        """
+        return self.confdata[self._tg]
+
+
+def get_config_data(key):
+    """
+    Get configuration data.
+
+    Parameters:
+    ----------
+    key: str
+        Key from the configuration data.
+
+    Return:
+       The configuration data, type varies.
+    """
+    try:
+        with OciMigrateConfParam(__ocimigrateconffile, key) as config:
+            return config.values()
+    except Exception as e:
+        raise OciMigrateException('Failed to get data for %s: %s' % (key, str(e)))

--- a/lib/oci_utils/migrate/__init__.py
+++ b/lib/oci_utils/migrate/__init__.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 
@@ -8,11 +8,21 @@ import os
 import sys
 import termios
 import tty
-import yaml
 
+import yaml
 from oci_utils.migrate.exception import OciMigrateException
 
-__ocimigrateconffile = '/etc/oci-utils/oci-migrate-conf.yaml'
+# try:
+#    import yaml
+# except ImportError as e:
+#    sys.stderr.write('\n  oci-image-migrate needs yaml module in order to '
+#                     'load configuration\n  data and to analyse certain '
+#                     'network configuration files. Install\n  it using the '
+#                     'package manager (python-yaml) or via pip (pip3 install '
+#                     'yaml.)\n')
+#    sys.exit(1)
+
+_oci_migrate_conf_file = '/etc/oci-utils/oci-migrate-conf.yaml'
 
 
 def _getch():
@@ -47,10 +57,10 @@ def read_yn(prompt, yn=True):
     -------
         bool: True on yes, False otherwise.
     """
-    thisprmpt = prompt + ' '
+    yn_prompt = prompt + ' '
     if yn:
-        thisprmpt += ' (y/N) '
-    sys.stdout.write(thisprmpt)
+        yn_prompt += ' (y/N) '
+    sys.stdout.write(yn_prompt)
     yn = _getch()
     sys.stdout.write('\n')
     if yn.upper() == 'Y':
@@ -59,7 +69,7 @@ def read_yn(prompt, yn=True):
         return False
 
 
-def exit_with_msg(msg, exitcode=1):
+def exit_with_msg(msg, exit_code=1):
     """
     Post a message on stdout and exit.
 
@@ -67,7 +77,7 @@ def exit_with_msg(msg, exitcode=1):
     ----------
     msg: str
         The exit message.
-    exitcode: int
+    exit_code: int
         The exit code, default is 1.
 
     Returns
@@ -75,7 +85,7 @@ def exit_with_msg(msg, exitcode=1):
         No return value.
     """
     sys.stderr.write('\n  %s\n' % msg)
-    exit(exitcode)
+    exit(exit_code)
 
 
 def pause_msg(msg=None):
@@ -115,11 +125,16 @@ def console_msg(msg=None):
     sys.stdout.write('\n  %s\n' % msg)
 
 
+def bytes_to_hex(bs):
+    return (''.join('%02x' % i for i in bs))
+
+
 class OciMigrateConfParam(object):
     """
     Retrieve oci-image-migrate configuration data from the
     oci-image-migrate configuration file, in yaml format.
     """
+
     def __init__(self, yamlconf, tag):
         """
         Initialisation of the oci image migrate configuration retrieval.
@@ -168,7 +183,8 @@ def get_config_data(key):
        The configuration data, type varies.
     """
     try:
-        with OciMigrateConfParam(__ocimigrateconffile, key) as config:
+        with OciMigrateConfParam(_oci_migrate_conf_file, key) as config:
             return config.values()
     except Exception as e:
-        raise OciMigrateException('Failed to get data for %s: %s' % (key, str(e)))
+        raise OciMigrateException(
+            'Failed to get data for %s: %s' % (key, str(e)))

--- a/lib/oci_utils/migrate/doc/oci_image_migrate.md
+++ b/lib/oci_utils/migrate/doc/oci_image_migrate.md
@@ -1,0 +1,180 @@
+# oci-utils.oci-image-migrate
+
+## Introduction
+
+oci-image-migrate prepares the image of an on-premise vm for being migrate to
+ the Oracle Cloud Infrastructure. The code detects the image type, the 
+ operating system as well as various configurations with respect to network, 
+ partitions, file systems, mount setup
+... 
+ The code is flexible and open for addition 
+ of new operating systems, new image type, new configurations.
+
+## Usage
+
+
+    # oci-image-migrate --help
+    usage: oci-image-migrate [-i INPUTIMAGE] [-b BUCKETNAME] [-o OUTPUTIMAGE]
+                             [--verbose] [--help]
+
+    Utility to support preparation of on-premise legacy images for importing in
+    the Oracle Cloud Infrastructure.
+
+    optional arguments:
+      -i INPUTIMAGE, --iimage INPUTIMAGE
+                            The on-premise image for migration to OCI.
+      -b BUCKETNAME, --bucket BUCKETNAME
+                            The destination bucket in OCI to store the converted
+                            image.
+      -o OUTPUTIMAGE, --oimage OUTPUTIMAGE
+                            The output image name.
+      --verbose, -v         Show verbose information.
+      --help                Display this help`
+
+The environment variable _OCI_UTILS_DEBUG changes the logging level of
+the python code. The default log level is ERROR, the debug flag changes
+it to INFO, the quiet flag to CRITICAL.
+ 
+## The image type
+
+The image type specific code has
+
+1. a dictionary **format_data** containing 1 key, the **magic number**
+   and a value which contains the dictionary of mandatory and optional
+   data. Mandatory are the **name**, the **module** name, the **class**
+   name. The **prereq** key is also optional and its value is structure
+   of image type prerequisites.
+
+    format_data = {'01234567': {'name': 'sometype',
+                                'module': 'sometype',
+                                'clazz': 'SomeTypeHead',
+                                'prereq': {'MAX_IMG_SIZE_GB': 300.0}}}
+                           
+1. a class definition **SomeTypeHead**,  which is a child of the 
+**DeviceData** class, contains a structure defining the header of the image 
+file, which has methods:
+   1. **show_header** to display the header data;
+   1. **image_size** to return a dictionary containig the physical and 
+   logical size for the image file in GigaBytes;
+   1. **image_supported** to test if the image is suppored;
+   1. **type_specific_prereq_test** to verify the image type specific 
+   prerequisites;
+   1. **image_data** which collects the data for this image type;
+
+## The operating system dependent code
+
+The code which is dependent of the operating system type, i.e. Oracle Linux 
+type or Ubuntu Linux type distributions currently.
+
+1. the tag **\_os_type_tag_csl_tag_type_os_** which is a list of operating 
+system ID's as they are presented in the **os-release** file;
+1. the method **install_cloud_init** which installs  the cloud_init and its 
+dependent packages;
+1. the method **update_network_config** to modify the network configuration 
+as required by the migration documentation;
+
+
+## The data structure
+
+The **DeviceData** class creates, completes and uses a dictionary 
+datastructure **img_info** for analysing the image:
+
+    img_name   <image file name>
+
+    img_type   [VMDK | qcow2]
+
+    img_header <contents is type dependent>
+
+    img_size  physical
+              logical
+
+    mbr    bin
+           hex
+           valid (bool)
+           partition_table [ {boot, type} ...]
+
+    parted Model
+           Disk
+           Partition Table
+
+    partitions /dev/nbd<n>p<m>  start
+                                size
+                                id
+                                bootable
+                                ID_FS_TYPE
+                                ID_FS_USAGE
+                                ID_FS_UUID
+                                ID_FS_UUID_ENC
+                                ID_FS_VERSION
+                                ID_PART_ENTRY_DISK
+                                ID_PART_ENTRY_NUMBER
+                                ID_PART_ENTRY_OFFSET
+                                ID_PART_ENTRY_SCHEME
+                                ID_PART_ENTRY_SIZE
+                                ID_PART_ENTRY_TYPE
+                                mountpoint
+                                usage [na| standard| boot| root]
+
+               /dev/nbd<n>p<m>  ....
+
+               /dev/mapper/<..> ...
+               ....
+               
+    volume_groups volume_group [ (logical volume, lv mapper), (logical volume, lv mapper),...]
+              ...
+
+    osinformation NAME
+                  VERSION
+                  ID
+                  ....
+
+    bootmnt  (boot partition, <current mountpoint of the boot partition>)
+
+    rootmnt  (root partition, <current mountpoint of the root partition>)
+
+    boot_type [BIOS|UEFI|NA]
+
+    fstab  (list of relevant fstab line as lists)
+
+    grubdata [ { cnt { menuentry : [ menuentry list] { search : [search list ] ... }       ]
+
+    network { networkdevice { network data...}} {  { }} ....
+
+    pseudomountlist [ list of mountpoints of pseudofs ]
+
+    remountlist [ list of mountpoints used while chroot]
+
+    ostype <ref to os dependent code>
+
+    oci_config {the contents of the oci cli configuration file}
+
+## Installation
+
+### Prerequisites
+
+   1. The git package is installed.
+
+   1. The developer channel is defined and enabled in the yum.repo.
+
+   1. The python setuptools package is at the latest release.
+
+   1. The oci cli package is installed and configured.
+
+### The install
+
+1. Pull the software from github:
+
+       # git clone https://github.com/guidotijskens/oci-utils.git
+
+1. Checkout the migrate branch:
+
+       # git checkout migrate
+
+1. Build the rpm:
+
+       # cd oci-utils
+       # ./setup.py -c create-rpm
+
+1. Install the rpm:
+
+       # yum localinstall oci-utils/rpmbuild/RPMS/noarch/oci-utils-migrate

--- a/lib/oci_utils/migrate/doc/oci_image_migrate.md
+++ b/lib/oci_utils/migrate/doc/oci_image_migrate.md
@@ -21,19 +21,18 @@ oci-image-migrate prepares the image of an on-premise vm for being migrate to
     the Oracle Cloud Infrastructure.
 
     optional arguments:
-      -i INPUTIMAGE, --iimage INPUTIMAGE
+      -i INPUTIMAGE, --input-mage INPUTIMAGE
                             The on-premise image for migration to OCI.
       -b BUCKETNAME, --bucket BUCKETNAME
                             The destination bucket in OCI to store the converted
                             image.
-      -o OUTPUTIMAGE, --oimage OUTPUTIMAGE
+      -o OUTPUTIMAGE, --output-image OUTPUTIMAGE
                             The output image name.
-      --verbose, -v         Show verbose information.
+      -v, --verbose         Show verbose information.
       --help                Display this help`
 
 The environment variable _OCI_UTILS_DEBUG changes the logging level of
-the python code. The default log level is ERROR, the debug flag changes
-it to INFO, the quiet flag to CRITICAL.
+the python code.
  
 ## The image type
 

--- a/lib/oci_utils/migrate/doc/oci_image_migrate_import.md
+++ b/lib/oci_utils/migrate/doc/oci_image_migrate_import.md
@@ -1,0 +1,67 @@
+# oci-utils.oci-image-migrate-import
+
+## Introduction
+
+oci-image-migrate-import imports an image from the object storage to the
+custom images repository in teh Oracle Cloud Infrastructure.
+
+## Usage
+
+    # oci-image-migrate-import --help
+    usage: oci-image-migrate-import.py -i IMAGENAME -b BUCKETNAME
+                                       -c COMPARTMENTNAME 
+                                       [-d DISPLAYNAME]
+                                       [-l {PARAVIRTUALIZED,EMULATED,NATIVE}]
+                                       [--verbose] [--help]
+
+    Utility to import a (verified and modified) on-premise legacy images which
+    was uploaded to object storage in the custom images folderof the Oracle
+    Cloud Infrastructure.
+
+    Arguments:
+    -i IMAGENAME, --image-name IMAGENAME
+                        The name of the object representing the uploaded
+                        image.
+    -b BUCKETNAME, --bucket-name BUCKETNAME
+                        The name of the object storage.
+    -c COMPARTMENTNAME, --compartment-name COMPARTMENTNAME
+                        The name of the destination compartment.
+    -d DISPLAYNAME, --display-name DISPLAYNAME
+                        Image name as it will show up in the custom images;
+                        the default is the image name.
+    -l {PARAVIRTUALIZED,EMULATED,NATIVE}, --launch-mode {PARAVIRTUALIZED
+                        ,EMULATED,NATIVE}
+                        The mode the instance created from the custom image
+                        will be started; the default is PARAVIRTUALIZED.
+    --verbose, -v         Show verbose information.
+    --help                Display this help
+
+The environment variable _OCI_UTILS_DEBUG changes the logging level of
+the python code.
+ 
+## Installation
+
+### Prerequisites
+
+   1. The git package is installed.
+
+   1. The oci cli package is installed and configured.
+
+### The install
+
+1. Pull the software from github:
+
+       # git clone https://github.com/guidotijskens/oci-utils.git
+
+1. Checkout the migrate branch:
+
+       # git checkout migrate
+
+1. Build the rpm:
+
+       # cd oci-utils
+       # ./setup.py -c create-rpm
+
+1. Install the rpm:
+
+       # yum localinstall oci-utils/rpmbuild/RPMS/noarch/oci-utils-migrate

--- a/lib/oci_utils/migrate/exception.py
+++ b/lib/oci_utils/migrate/exception.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 

--- a/lib/oci_utils/migrate/exception.py
+++ b/lib/oci_utils/migrate/exception.py
@@ -1,0 +1,68 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+""" Module with oci migrate related exceptions.
+"""
+
+
+class OciMigrateException(Exception):
+    """ Exceptions for the Image Migrate to OCI context.
+    """
+    __args = None
+
+    def __init__(self, message=None):
+        """
+        Initialisation of the Oci Migrate Exception.
+
+        Parameters
+        ----------
+        message: str
+            The exception message.
+        """
+        self._message = message
+        assert (self._message is not None), 'No exception message given'
+
+        if self._message is None:
+            self._message = 'An exception occurred, no further information'
+
+    def __str__(self):
+        """
+        Get this OCISDKError representation.
+
+        Returns
+        -------
+        str
+            The error message.
+        """
+        return str(self._message)
+
+
+class NoSuchCommand(OciMigrateException):
+    """ Exception for command not found.
+    """
+    def __init__(self, command):
+        """
+        Initialisation of the No Such Command' exception.
+
+        Parameters
+        ----------
+        command: str
+            The missing command, exec or script.
+        """
+        self._command = command
+        assert (self._command is not None), 'No command given'
+
+    def __str__(self):
+        """
+        Get this OCISDKError representation.
+
+        Returns
+        -------
+        str
+            The error message.
+        """
+
+        return str(self.message)

--- a/lib/oci_utils/migrate/imgdevice.py
+++ b/lib/oci_utils/migrate/imgdevice.py
@@ -1,0 +1,1409 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module to handle device data.
+"""
+
+import importlib
+import logging
+import os
+import re
+import six
+import sys
+import threading
+import time
+
+from glob import glob as glob
+from oci_utils.migrate import console_msg, pause_msg
+from oci_utils.migrate import get_config_data
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate import migrate_utils
+from oci_utils.migrate import reconfigure_network
+from oci_utils.migrate.exception import OciMigrateException
+
+_logger = logging.getLogger('oci-utils.imgdevice')
+
+
+class UpdateImage(threading.Thread):
+    """ Class to update the virtual disk image in a chroot jail.
+    """
+  
+    def __init__(self, vdiskdata, clouddata):
+        """
+        Initialisation of the UpdateImage object.
+
+        Parameters:
+        ----------
+            vdiskdata: dict
+                Information about the virtual image as described in the
+                readme.txt, img_info.
+            clouddata: dict
+                cloudconfig_file: str
+                    Full path of the cloud.cfg file
+                default_clouduser: str
+                    The user name for the oci user.
+        """
+        self._imgdata = vdiskdata
+        self._clouddata = clouddata
+        threading.Thread.__init__(self)
+
+    def run(self):
+        """Run the chroot operations
+        """
+        _logger.debug('Opening Thread.')
+        self.chrootjail_ops()
+
+    def wait4end(self):
+        """ Stop
+        """
+        _logger.debug('Waiting for end.')
+        self.join()
+
+    def chrootjail_ops(self):
+        """
+        Create the chroot jail and execute the operations in the changed root.
+
+        Returns
+        -------
+            No return value.
+        """
+        migrate_tools.result_msg(msg='Creating chroot jail.')
+        pause_msg('chroot jail entry')
+        os_type = self._imgdata['ostype']
+        try:
+            self._imgdata['pseudomountlist'] \
+                = migrate_utils.mount_pseudo(self._imgdata['rootmnt'][1])
+            migrate_tools.result_msg(msg='Mounted proc, sys, dev')
+            #
+            # chroot
+            _logger.debug('New root: %s' % self._imgdata['rootmnt'][1])
+            rootfd, pathsave = migrate_utils.enter_chroot(self._imgdata['rootmnt'][1])
+            _logger.debug('Changed root to %s.' % self._imgdata['rootmnt'][1])
+            #
+            # check current working directory
+            thiscwd = os.getcwd()
+            _logger.debug('Current working directory is %s' % thiscwd)
+            #
+            # verify existence /etc/resolve.conf
+            if migrate_tools.file_exists('/etc/resolv.conf'):
+                _logger.debug('File /etc/resolv.conf found.')
+            else:
+                _logger.debug('No file /etc/resolv.conf found')
+                if migrate_tools.link_exists('/etc/resolv.conf'):
+                    _logger.debug('/etc/result.conf is a symbolic link.')
+                else:
+                    _logger.debug('Really no /etc/resolv.conf.')
+            #
+            # Install cloud-init
+            pause_msg('In chroot:')
+            pre_cloud_notification = 'Please verify nameserver, proxy, ' \
+                                     'update-repository configuration before ' \
+                                     'proceeding the cloud-init package ' \
+                                     'install.'
+            pause_msg(pre_cloud_notification)
+            console_msg('Installing the cloud-init package, this might take a while.')
+            cloud_init_install = migrate_tools.ProgressBar(1, 0.5)
+            cloud_init_install.start()
+            if os_type.install_cloud_init(self._imgdata['osinformation']['VERSION_ID']):
+                _logger.debug('Successfully installed cloud-init')
+            else:
+                _logger.critical('Failed to install cloud init')
+                raise OciMigrateException('Failed to install cloud init')
+            #
+            # Update cloud.cfg file with default user
+            pause_msg('cloud-init installed, updating default user')
+            if migrate_utils.set_default_user(self._clouddata['cloudconfig_file'],
+                                              self._clouddata['default_clouduser']):
+                _logger.debug('Default cloud user updated.')
+            else:
+                _logger.error('Failed to update default cloud user.')
+                raise OciMigrateException('Failed to update default cloud user.')
+        except Exception as e:
+            _logger.critical('*** ERROR *** Unable to perform image update '
+                             'operations: %s' % str(e), exc_info=True)
+        finally:
+            if migrate_tools.isthreadrunning(cloud_init_install):
+                cloud_init_install.stop()
+            migrate_utils.leave_chroot(rootfd)
+            _logger.debug('Left chroot jail.')
+            migrate_utils.unmount_pseudo(self._imgdata['pseudomountlist'])
+            migrate_tools.result_msg(msg='Unmounted proc, sys, dev.')
+        time.sleep(1)
+        migrate_tools.result_msg(msg='Leaving chroot jail.')
+
+
+class DeviceData(object):
+    """
+    Class to handle the data of device and partitions in an virtual disk
+    image file. Contains methods shared by various image file types.
+    """
+    def __init__(self, filename):
+        """
+        Parameters:
+        ----------
+            Initialisation of the generic header.
+            filename: str
+                The full path of the virtual disk image file.
+        """
+        self._fn = filename
+        self._devicename = None
+        self._img_info = dict()
+        self._mountpoints = list()
+        _logger.debug('Image file name: %s' % self._fn)
+
+    def mount_img(self):
+        """
+        Loopback mount the image file on /dev/nbd.
+
+        Returns
+        -------
+            str: mount point on success, None on failure, reraises an
+            eventual exception.
+        """
+        _logger.debug('Entering mount')
+        try:
+            nbdpath = migrate_utils.mount_imgfn(self._fn)
+            _logger.debug('%s successfully mounted' % nbdpath)
+            return nbdpath
+        except Exception as e:
+            _logger.critical(str(e))
+            raise OciMigrateException(str(e))
+
+    def umount_img(self, nbd):
+        """
+        Unmount loopback mounted image file.
+
+        Returns
+        -------
+            bool: True on success, False Otherwise.
+        """
+        try:
+            if migrate_utils.unmount_imgfn(nbd):
+                _logger.debug('%s successfully unmounted' % nbd)
+                return True
+            else:
+                _logger.error('Failed to unmount %s' % nbd, exc_info=True)
+                return False
+        except Exception as e:
+            raise OciMigrateException(str(e))
+
+    def get_mbr(self, device):
+        """
+        Collect the Master Boot Record from the device.
+
+        Parameters
+        ----------
+        device: str
+            The device name.
+
+        Returns
+        -------
+            bytearray: the MBR on success, None on failure.
+        """
+        cmd = ['dd', 'if=%s' % device, 'bs=512', 'count=1']
+        try:
+            mbr = migrate_tools.run_popen_cmd(cmd)
+            _logger.debug('%s mbr: %s' % (device, mbr.encode('hex_codec')))
+            return mbr
+        except Exception as e:
+            _logger.error('Failed to read MBR on %s: %s' % (device, str(e)))
+            return None
+
+    def get_partition_table(self, mbr):
+        """
+        Collect and analyse partition table in MBR.
+
+        Parameters
+        ----------
+        mbr: the 512 byte MBR.
+
+        Returns
+        -------
+            bool: True if block has MBR signature, False otherwise.
+            list: list with partiton table.
+        """
+        bootflag = '80'
+        mbrok = False
+        partitiontable = list()
+        hexmbr = mbr.encode('hex_codec')
+        mbrsig = hexmbr[-4:]
+        if mbrsig.upper() == '55AA':
+            mbrok = True
+            _logger.debug('Is a valid MBR')
+        else:
+            _logger.critical('Is not a valid MBR')
+            return mbrok, partitiontable
+
+        ind = 892
+        for i in range(0, 4):
+            part = dict()
+            partentry = hexmbr[ind:ind+32]
+            part['entry'] = partentry
+            ind += 32
+            #
+            # active partition: find partition with bootflag
+            _logger.debug('boot? : %s' % partentry[0:2])
+            if partentry[0:2] == bootflag:
+                part['boot'] = True
+            else:
+                part['boot'] = False
+            #
+            # type
+            typeflag = partentry[8:10].lower()
+            _logger.debug('type? : %s' % typeflag)
+            parttypes = get_config_data('partition_types')
+            if typeflag in parttypes:
+                part['type'] = parttypes[typeflag]
+            else:
+                part['type'] = 'unknown'
+
+            partitiontable.append(part)
+
+        _logger.debug('Partition table: %s' % partitiontable)
+        return mbrok, partitiontable
+
+    def get_partition_info(self, partitionname):
+        """
+        Collect information about partition.
+
+        Parameters
+        ----------
+        partitionname: str
+            The partition name.
+
+        Returns
+        -------
+            dict: The information about the partition
+        """
+        #
+        # blkid data
+        _logger.debug('Collecting information on %s' % partitionname)
+        blkid_args = ['-po', 'udev']
+        blkid_args.append(partitionname)
+        _logger.debug('blkid %s' % blkid_args)
+        migrate_tools.result_msg(msg='Investigating partition %s' % partitionname)
+        part_info = dict()
+        blkidres = migrate_utils.exec_blkid(blkid_args)
+        if blkidres is None:
+            raise OciMigrateException('Failed to run blkid %s' % blkidres)
+        else:
+            _logger.debug('%s output: blkid\n %s'
+                               % (blkid_args, blkidres.split()))
+        #
+        # make dictionary
+        for kv in blkidres.splitlines():
+            kvs = kv.split('=')
+            part_info[kvs[0]] = kvs[1]
+        #
+        # add supported entry
+        if 'ID_FS_TYPE' in part_info:
+            parttype = part_info['ID_FS_TYPE']
+            #
+            # verify partition type is supported
+            migrate_tools.result_msg(msg='Partition type %s' % parttype)
+            if parttype in get_config_data('filesystem_types'):
+                _logger.debug('Partition %s contains filesystem %s'
+                                   % (partitionname, parttype))
+                part_info['supported'] = True
+                part_info['usage'] = 'standard'
+            elif parttype in get_config_data('logical_vol_types'):
+                _logger.debug('Partition %s contains a logical volume %s'
+                                   % (partitionname, parttype))
+                part_info['supported'] = True
+                part_info['usage'] = 'standard'
+            elif parttype in get_config_data('partition_to_skip'):
+                _logger.debug('Partition %s harmless: %s'
+                                   % (partitionname, parttype))
+                part_info['supported'] = False
+                part_info['usage'] = 'na'
+                migrate_tools.result_msg(msg='Partition type %s for %s is not '
+                                     'supported but harmless, skipping.\n'
+                                     % (partitionname, parttype))
+            else:
+                _logger.debug('Partition %s unusable: %s'
+                                   % (partitionname, parttype))
+                part_info['supported'] = False
+                part_info['usage'] = 'na'
+                migrate_tools.error_msg('Partition type %s for %s is not '
+                                    'supported, quitting.\n'
+                                    % (parttype, partitionname))
+                raise OciMigrateException('Partition type %s for %s is not '
+                                          'recognised and may break the '
+                                          'operation.'
+                                          % (parttype, partitionname))
+        else:
+            # raise OciMigrateException('FS type missing from partition '
+            #                           'information %s' % partitionname)
+            part_info['supported'] = False
+            part_info['usage'] = 'na'
+            _logger.debug('No partition type specified, skipping')
+            migrate_tools.result_msg(msg='No partition type found for %s, skipping.'
+                                 % partitionname)
+        #
+        # get label, if any
+        partition_label = migrate_utils.exec_lsblk(['-n', '-o', 'LABEL',
+                                                    partitionname])
+        if len(partition_label.rstrip()) > 0:
+            migrate_tools.result_msg(msg='Partition label: %s' % partition_label)
+            part_info['label'] = partition_label.rstrip()
+        else:
+            _logger.debug('No label on %s.' % partitionname)
+        #
+        pause_msg('test partition info')
+        return part_info
+
+    def handle_image(self):
+        """
+        Process the image.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+        """
+        try:
+            #
+            # mount image.
+            self._devicename = self.mount_img()
+            #
+            # collect the image data.
+            image_date_result = self.get_image_data()
+            #
+            # mount filesystems.
+            if not self.mount_filesystems():
+                raise OciMigrateException('Failed to mount filessystems')
+            else:
+                _logger.debug('Mounting file systems succeeded.')
+            pause_msg('file systems mounted')
+            #
+            # collect os data.
+            _ = self.collect_os_data()
+            #
+            # pause here for test reasons..
+            pause_msg('pausing here for test reasons')
+            #
+            # update the network configuration.
+            if reconfigure_network.update_network_config(self._img_info['rootmnt'][1]):
+                _logger.debug('Successfully upgraded the network configuration.')
+            else:
+                _logger.error('Failed to update network configuration.')
+                raise OciMigrateException('Failed to update network configuration.')
+            # pause here for test reasons..
+            pause_msg('pausing here for test reasons')
+            #
+            # update the image.
+            _ = self.update_image()
+            #
+            # just for the matter of completeness:
+            # get the oci configuration.
+            ociconfig = migrate_utils.get_oci_config()
+            self._img_info['oci_config'] = ociconfig
+            return True
+        except Exception as e:
+            _logger.critical('Image %s handling failed: %s'
+                             % (self._img_info['img_name'], str(e)), exc_info=True)
+            return False
+        finally:
+            #
+            # unmount partitions from remount
+            _logger.debug('Unmount partitions.')
+            if self.unmount_partitions():
+                _logger.debug('Successfully unmounted.')
+            else:
+                migrate_tools.error_msg('Failed to release remounted '
+                                        'filesystems, might prevent successful '
+                                        'completions of %s.' % sys.argv[0])
+            #
+            # unmount filesystems
+            _logger.debug('Unmount filesystems.')
+            for mnt in self._mountpoints:
+                _logger.debug('--- %s' % mnt)
+                migrate_utils.unmount_part(mnt)
+            #
+            # release lvm
+            _logger.debug('release volume groups')
+            if 'volume_groups' in self._img_info:
+                migrate_utils.unmount_lvm2(self._img_info['volume_groups'])
+            else:
+                _logger.debug('No volume groups defined.')
+            #
+            # release device and module
+            if self._devicename:
+                _logger.debug('Releasing %s' % str(self._devicename))
+                self.umount_img(self._devicename)
+                if migrate_utils.rm_nbd():
+                    _logger.debug('Kernel module nbd removed.')
+                else:
+                    _logger.error('Failed to remove kernel module nbd.')
+
+    def get_image_data(self):
+        """
+        Get file system on the partition specified by device.
+
+        Returns
+        -------
+            bool: True on success, raises an exception otherwise.
+        """
+        #
+        # reading from the mounted image file
+        _logger.debug('Collecting data on %s' % self._devicename)
+        try:
+            #
+            # Master Boot Record:
+            thismbr = self.get_mbr(self._devicename)
+            if thismbr is None:
+                raise OciMigrateException('Failed to get MBR from '
+                                          'device file %s' % self._devicename)
+            else:
+                self._img_info['mbr'] = \
+                    {'bin': thismbr, 'hex': migrate_utils.show_hex_dump(thismbr)}
+                migrate_tools.result_msg(msg='Found MBR.', result=True)
+            #
+            # Partition Table from MBR:
+            mbrok, parttable = self.get_partition_table(self._img_info['mbr']['bin'])
+            if not mbrok:
+                raise OciMigrateException('Failed to get partition table from MBR')
+            else:
+                self._img_info['mbr']['valid'] = mbrok
+                self._img_info['mbr']['partition_table'] = parttable
+                migrate_tools.result_msg(msg='Found partition table.', result=True)
+            #
+            # Device data
+            parted_data = migrate_utils.exec_parted(self._devicename)
+            if parted_data is None:
+                raise OciMigrateException('Failed to collect parted %s '
+                                          'device data.' % self._devicename)
+            else:
+                self._img_info['parted'] = parted_data
+                migrate_tools.result_msg(msg='Got parted data')
+                _logger.debug('partition data: %s'
+                                   % self._img_info['parted'])
+            #
+            # Partition info
+            sfdisk_info = migrate_utils.exec_sfdisk(self._devicename)
+            if sfdisk_info is None:
+                raise OciMigrateException('Failed to collect sfdisk %s '
+                                          'partition data.' % self._devicename)
+            else:
+                migrate_tools.result_msg(msg='Got sfdisk info')
+                self._img_info['partitions'] = sfdisk_info
+                _logger.debug('Partition info: %s' % sfdisk_info)
+                _logger.debug('Partition info: %s'
+                                   % self._img_info['partitions'])
+                for k, v in six.iteritems(self._img_info['partitions']):
+                    _logger.debug('%s - %s' % (k, v))
+                    v['usage'] = 'na'
+                    v['supported'] = False
+            #
+            # Partition data
+            parttemplate = self._devicename + 'p*'
+            _logger.debug('Partition %s : %s'
+                               % (parttemplate, glob(parttemplate)))
+            migrate_tools.result_msg(msg='Partition data for device %s'
+                                     % self._devicename)
+            #
+            # testing purposes
+            pause_msg('verify blkid..')
+            for partname in glob(parttemplate):
+                _logger.debug('Get info on %s' % partname)
+                self._img_info['partitions'][partname].update(
+                    self.get_partition_info(partname))
+            return True
+        except Exception as e:
+            #
+            # need to release mount of image file and exit
+            _logger.critical('Initial partition data collection '
+                                  'failed: %s' % str(e), exc_info=True)
+            raise OciMigrateException('Initial partition data collection '
+                                      'failed:\n %s' % str(e))
+
+    def mount_filesystems(self):
+        """
+        Mount the file systems in partitons and logical volumes.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+        """
+        #
+        # initialise logical volume structure
+        self._img_info['volume_groups'] = dict()
+        #
+        # initialise list of mountpoints
+        migrate_tools.result_msg(msg='Mounting partitions.')
+        #
+        # loop through identified partitions, identify the type, mount it if
+        # it is a standard partition hosting a supported filesystem; if a
+        # partition contains a LVM2 physical volume, add the partition to the
+        # lvm list for later use.
+        success = True
+        pause_msg(self._img_info['partitions'])
+        for devname, devdetail in six.iteritems(self._img_info['partitions']):
+            _logger.debug('Device: %s' % devname)
+            _logger.debug('Details:\n %s' % devdetail)
+            migrate_tools.result_msg(msg='Partition %s' % devname)
+            try:
+                if 'ID_FS_TYPE' in devdetail:
+                    if devdetail['ID_FS_TYPE'] in get_config_data('filesystem_types'):
+                        _logger.debug('File system %s detected'
+                                           % devdetail['ID_FS_TYPE'])
+                        thismountpoint = migrate_utils.mount_partition(devname)
+                        if thismountpoint is not None:
+                            migrate_tools.result_msg(msg='Partition %s with file '
+                                                 'system %s mounted on %s.'
+                                                 % (devname,
+                                                    devdetail['ID_FS_TYPE'],
+                                                    thismountpoint),
+                                                 result=True)
+                            _logger.debug('%s mounted' % devname)
+                            devdetail['mountpoint'] = thismountpoint
+                            self._mountpoints.append(thismountpoint)
+                        else:
+                            _logger.critical('Failed to mount %s'
+                                                  % devname)
+                            success = False
+                    elif devdetail['ID_FS_TYPE'] in get_config_data('logical_vol_types'):
+                        _logger.debug('Logical volume %s detected'
+                                           % devdetail['ID_FS_TYPE'])
+                        migrate_tools.result_msg(msg='Logical volume %s'
+                                                 % devdetail['ID_FS_TYPE'],
+                                             result=True)
+                        volume_groups = migrate_utils.mount_lvm2(devname)
+                        self._img_info['volume_groups'].update(volume_groups)
+                    else:
+                        _logger.debug('Skipping %s.' % devdetail['ID_FS_TYPE'])
+                        migrate_tools.result_msg(msg='Skipping %s'
+                                                 % devdetail['ID_FS_TYPE'])
+                else:
+                    _logger.debug('%s does not exist or has '
+                                       'unrecognised type' % devname)
+            except Exception as e:
+                #
+                # failed to mount a supported filesystem on a partition...
+                # not quitting yet, trying to collect as much info a possible
+                # in this stage.
+                success = False
+                _logger.critical('Failed to mount partition %s: %s'
+                                      % (devname, str(e)))
+        #
+        # loop through the volume group list, identify the logical volumes
+        # and mount them if they host a supported file system.
+        for vg, lv in six.iteritems(self._img_info['volume_groups']):
+            _logger.debug('volume group %s' % vg)
+            for part in lv:
+                partname = '/dev/mapper/%s' % part[1]
+                _logger.debug('Partition %s' % partname)
+                migrate_tools.result_msg(msg='Partition: %s' % partname)
+                #
+                # for the sake of testing
+                pause_msg('lv name test')
+                devdetail = self.get_partition_info(partname)
+                try:
+                    if 'ID_FS_TYPE' in devdetail:
+                        if devdetail['ID_FS_TYPE'] in get_config_data('filesystem_types'):
+                            _logger.debug('file system %s detected'
+                                               % devdetail['ID_FS_TYPE'])
+                            thismountpoint = migrate_utils.mount_partition(partname)
+                            if thismountpoint is not None:
+                                migrate_tools.result_msg(
+                                    msg='Partition %s with file system %s '
+                                        'mounted on %s.'
+                                        % (partname, devdetail['ID_FS_TYPE'],
+                                           thismountpoint), result=True)
+                                _logger.debug('%s mounted' % partname)
+                                devdetail['mountpoint'] = thismountpoint
+                                self._mountpoints.append(thismountpoint)
+                            else:
+                                _logger.critical('Failed to mount %s'
+                                                      % partname)
+                                success = False
+                        else:
+                            _logger.debug('%s does not exist or has '
+                                               'unrecognised type' % partname)
+                    self._img_info['partitions'][partname] = devdetail
+                except Exception as e:
+                    success = False
+                    _logger.critical('Failed to mount logical '
+                                          'volumes %s: %s' % (partname, str(e)))
+        return success
+
+    def remount_partitions(self):
+        """
+        Remount the partitions identified in fstab on the identified root
+        partition.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+        """
+        # self._img_info['remountlist'] = []
+        rootfs = self._img_info['rootmnt'][1]
+        _logger.debug('Mounting on %s' % rootfs)
+        # Loop through partition list and create a sorted list of the
+        # non-root partitions and mount those on the root partition.
+        # The list is sorted to avoid overwriting subdirectory mounts like
+        # /var, /var/log, /van/log/auto,.....
+        mountlist = []
+        for k, v in six.iteritems(self._img_info['partitions']):
+            _logger.debug('remount?? %s' % k)
+            _logger.debug('remount?? %s' % v)
+            if 'ID_FS_TYPE' not in v:
+                _logger.debug('%s is not in use' % k)
+            else:
+                if v['ID_FS_TYPE'] in get_config_data('filesystem_types'):
+                    if v['usage'] not in ['root', 'na']:
+                        mountlist.append((v['usage'], k, v['mountpoint']))
+                    else:
+                        _logger.debug('Partition %s not required.' % k)
+                else:
+                    _logger.debug('Type %s not a mountable file '
+                                       'system type.' % v['ID_FS_TYPE'])
+        mountlist.sort()
+        _logger.debug('mountlist: %s' % mountlist)
+
+        for part in mountlist:
+            _logger.debug('Is %s a candidate?' % part[0])
+            mountdir = rootfs + '/' + part[0]
+            _logger.debug('Does mountpoint %s exist?' % mountdir)
+            if migrate_tools.dir_exists(mountdir):
+                _logger.debug('Mounting %s on %s.' % (part[1], mountdir))
+                try:
+                    resultmnt = migrate_utils.mount_partition(part[1], mountdir)
+                    if resultmnt is not None:
+                        _logger.debug('Mounted %s successfully.' % resultmnt)
+                        migrate_tools.result_msg(msg='Mounted %s on %s.'
+                                             % (part[1], mountdir),
+                                             result=True)
+                        self._img_info['remountlist'].append(resultmnt)
+                    else:
+                        _logger.error('Failed to mount %s.' % mountdir,
+                                           exc_info=True)
+                        raise OciMigrateException('Failed to mount %s'
+                                                  % mountdir)
+                except Exception as e:
+                    _logger.error('Failed to mount %s: %s.'
+                                       % (mountdir, str(e)), exc_info=True)
+                    # not sure where to go from here
+            else:
+                _logger.error('Something wrong, %s does not exist.' %
+                                   mountdir)
+
+        return True
+
+    def unmount_partitions(self):
+        """
+        Unmount partitions mounted earlier and listed in image info dict as
+        'remountlist'.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+        """
+        ret = True
+        if 'remountlist' in self._img_info:
+            if len(self._img_info['remountlist']) <= 0:
+                return ret
+
+            self._img_info['remountlist'].sort()
+            for part in self._img_info['remountlist']:
+                _logger.debug('Releasing %s' % part)
+                if migrate_utils.unmount_something(part):
+                    _logger.debug('Successfully released %s.' % part)
+                else:
+                    _logger.error('Failed to release %s, might prevent '
+                                       'clean termination.' % part,
+                                       exc_info=True)
+                    ret = False
+        else:
+            _logger.debug('No remountlist.')
+        return ret
+
+    def collect_os_data(self):
+        """
+        Collect OS data relevant for the migration of the image to OCI and
+        save it in the img_info dictionary.
+
+        Returns
+        -------
+            bool: True on success, raise exception otherwise.
+        """
+        self._img_info['remountlist'] = list()
+        #
+        # Collect the data
+        oscollectmesg = ''
+        try:
+            #
+            # import operation system type dependant modules
+            osrelease = self.get_os_release()
+            if not osrelease:
+                oscollectmesg += '\n  . Unable to collect OS information.'
+            else:
+                self._img_info['osinformation'] = osrelease
+                _logger.debug('OS type: %s' % osrelease['ID'])
+            #
+            # import os-type specific modules
+            os_spec_mod = migrate_utils.find_os_specific(osrelease['ID'])
+            _logger.debug('OS specification: %s' % os_spec_mod)
+            if os_spec_mod is None:
+                oscollectmesg += '\n  . OS type %s is not recognised.' \
+                                 % osrelease['ID']
+            else:
+                self._img_info['ostype'] = \
+                    importlib.import_module('oci_utils.migrate.' + os_spec_mod)
+                _logger.debug('OS type: %s' % self._img_info['ostype'])
+                self._img_info['ostype'].os_banner()
+            #
+            pause_msg('root and boot')
+            #
+            # root and boot
+            rootpart, rootmount = self.identify_partitions()
+            if rootpart is None:
+                oscollectmesg += '\n  . Failed to locate root partition.'
+            else:
+                migrate_tools.result_msg(msg='Root %s %s' % (rootpart, rootmount))
+                self._img_info['rootmnt'] = [rootpart, rootmount]
+                _logger.debug('root: %s' % self._img_info['rootmnt'])
+            bootpart, bootmount = self.get_partition('/boot')
+            if bootpart is None:
+                migrate_tools.result_msg(msg='/boot is not on a separate partition '
+                                     'or is missing. The latter case which '
+                                     'will cause failure.', result=True)
+            else:
+                migrate_tools.result_msg(msg='Boot %s %s' % (bootpart, bootmount))
+            self._img_info['bootmnt'] = [bootpart, bootmount]
+            _logger.debug('boot: %s' % self._img_info['bootmnt'])
+            #
+            # remount image partitions on root partition
+            if self.remount_partitions():
+                _logger.debug('Essential partitions mounted.')
+                pause_msg('Verify mounted partitions')
+            else:
+                raise OciMigrateException('Failed to mount essential partitions.')
+            #
+            if oscollectmesg:
+                raise OciMigrateException(oscollectmesg)
+            else:
+                _logger.debug('OS data collected.')
+            #
+            # grub
+            self._img_info['grubdata'] = self.get_grub_data(self._img_info['rootmnt'][1])
+            #
+        except Exception as e:
+            _logger.critical('Failed to collect os data: %s' % str(e),
+                                  exc_info=True)
+            raise OciMigrateException('Failed to collect os data: %s' % str(e))
+        return True
+
+    def update_image(self):
+        """
+        Prepare the image for migration by installing the cloud-init package.
+
+        Returns
+        -------
+            No return value, raises an exception on failure
+        """
+        try:
+            cldata = dict()
+            cldata['cloudconfig_file'] = get_config_data('cloudconfig_file')
+            cldata['default_clouduser'] = get_config_data('default_clouduser')
+            _logger.debug('Updating image.')
+            updimg = UpdateImage(self._img_info, cldata)
+            updimg.start()
+            _logger.debug('Waiting for update to end.')
+            updimg.wait4end()
+        except Exception as e:
+            _logger.error('Failed: %s' % str(e), exc_info=True)
+            raise OciMigrateException(str(e))
+        finally:
+            _logger.debug('NOOP')
+
+    def get_partition(self, mnt):
+        """
+        Find the partition in the device data structure which has a usage
+        specified in 'mnt'.
+
+        Parameters:
+        ----------
+            mnt: str
+                The usage as specified in the img_info.partitions info
+
+        Returns
+        -------
+            tuple: partition, mountpoint on success, None otherwise.
+        """
+        thepartitions = self._img_info['partitions']
+        for k, v in six.iteritems(thepartitions):
+            if 'usage' in v:
+                if v['usage'] == mnt:
+                    _logger.debug('Found %s in %s' % (mnt, v['mountpoint']))
+                    return k, v['mountpoint']
+            else:
+                _logger.debug('%s has no usage entry, skipping.' % k)
+        _logger.debug('%s not found.' % mnt)
+        return None, None
+
+    def identify_partitions(self):
+        """
+        Locate the root partition and collect relevant data; /etc/fstab is
+        supposed to be on the root partition.
+        Identify all partitions in the image.
+
+        Returns
+        -------
+            tuple: (root partition, root mountpoint) on success,
+            (None, None) otherwise
+        """
+        thisfile = 'fstab'
+        _logger.debug('Looking for root and boot partition in %s'
+                           % self._mountpoints)
+        rootpart, rootmount, bootpart, bootmount = None, None, None, None
+        try:
+            for mnt in self._mountpoints:
+                etcdir = mnt + '/etc'
+                _logger.debug('Looking in partition %s' % mnt)
+                fstab = migrate_utils.exec_search(thisfile, etcdir)
+                if fstab is not None:
+                    #
+                    # found fstab, reading it
+                    # self._img_info['fstab'] = self.get_fstab()
+                    fstabdata = self.get_fstab(fstab)
+                    self._img_info['fstab'] = fstabdata
+                    for line in fstabdata:
+                        _logger.debug('Checking %s' % line)
+                        if line[1] in get_config_data('partition_to_skip'):
+                            _logger.debug('Skipping %s' % line)
+                        elif line[1] == '/':
+                            _logger.debug('Root partition is %s.' % line[0])
+                            rootpart, rootmount = self.find_partition(line[0])
+                            if (rootpart, rootmount) == (None, None):
+                                _logger.critical(
+                                    'Failed to locate root partition %s.' % line[0])
+                                raise OciMigrateException(
+                                    'Failed to locate root partition %s.' % line[0])
+                            else:
+                                self._img_info['partitions'][rootpart]['usage'] \
+                                    = 'root'
+                        else:
+                            _logger.debug('Some other partition %s for %s.'
+                                               % (line[0], line[1]))
+                            part, mount = self.find_partition(line[0])
+                            if (part, mount) == (None, None):
+                                _logger.debug(
+                                    'Partition %s not used or not present.'
+                                    % line[0])
+                                raise OciMigrateException(
+                                    'Failed to locate a partition %s.'
+                                    % line[0])
+                            else:
+                                self._img_info['partitions'][part]['usage'] = line[1]
+                        migrate_tools.result_msg(msg='Identified partition %s'
+                                             % line[1], result=True)
+                    migrate_tools.result_msg(msg='Root partition is mounted on %s.'
+                                             % rootmount)
+                    break
+                else:
+                    _logger.debug('fstab not found in %s' % etcdir)
+        except Exception as e:
+            _logger.critical('Error in partition identification: %s'
+                                  % str(e))
+            raise OciMigrateException('Error in partition identification: %s'
+                                      % str(e))
+        return rootpart, rootmount
+
+    def skip_partition(self, partdata):
+        """
+        Verify if partition is to be included.
+
+        Parameters
+        ----------
+        partdata: dict
+            Partition data.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+        """
+        skip_part = True
+        _logger.debug(partdata)
+        # migrate_tools.result_msg('skip: ')
+        if 'ID_FS_TYPE' in partdata:
+            _logger.debug('Skip %s?' % partdata['ID_FS_TYPE'])
+            if partdata['ID_FS_TYPE'] not in get_config_data('partition_to_skip'):
+                _logger.debug('No skip')
+                skip_part = False
+            else:
+                _logger.debug('Skip')
+        else:
+            _logger.debug('Skip anyway.')
+        pause_msg('partition %s' % skip_part)
+        return skip_part
+
+    def find_partition(self, uuidornameorlabel):
+        """
+        Identify a partition and its current mount point with respect to a
+        UUID or LABEL or LVM2name.
+
+        Parameters
+        ----------
+        uuidornameorlabel: str
+            The UUID, LABEL or LVM2 name as specified in fstab.
+
+        Returns
+        -------
+            tuple: The partition, the current mount point.
+        """
+        part, mount = None, None
+        if 'UUID' in uuidornameorlabel:
+            uuid_x = re.split('\\bUUID=\\b', uuidornameorlabel)[1]
+            _logger.debug('%s contains a UUID: %s'
+                               % (uuidornameorlabel, uuid_x))
+            for partition, partdata in six.iteritems(self._img_info['partitions']):
+                if self.skip_partition(partdata):
+                    _logger.debug('Skipping %s' % partition)
+                elif 'ID_FS_UUID' in partdata.keys():
+                    if partdata['ID_FS_UUID'] == uuid_x:
+                        part = partition
+                        mount = partdata['mountpoint']
+                        _logger.debug('%s found in %s' % (uuid_x, partition))
+                        break
+                    else:
+                        _logger.debug('%s not in %s' % (uuid_x, partition))
+                else:
+                    _logger.debug('%s : No ID_FS_UUID in partdata keys.'
+                                       % partition)
+            _logger.debug('break..UUID')
+        elif 'LABEL' in uuidornameorlabel:
+            label_x = re.split('\\bLABEL=\\b', uuidornameorlabel)[1]
+            _logger.debug('%s contains a LABEL: %s'
+                               % (uuidornameorlabel, label_x))
+            for partition, partdata in six.iteritems(self._img_info['partitions']):
+                if self.skip_partition(partdata):
+                    _logger.debug('Skipping %s' % partition)
+                elif 'ID_FS_LABEL' in partdata.keys():
+                    if partdata['ID_FS_LABEL'] == label_x:
+                        part = partition
+                        mount = partdata['mountpoint']
+                        _logger.debug('%s found in %s' % (label_x, partition))
+                        break
+                    else:
+                        _logger.debug('%s not in %s' % (label_x, partition))
+                else:
+                    _logger.debug('%s: No ID_FS_LABEL in partdata keys.'
+                                       % partition)
+            _logger.debug('break..LABEL')
+        elif 'mapper' in uuidornameorlabel:
+            lv_x = re.split('\\bmapper/\\b', uuidornameorlabel)
+            _logger.debug('%s contains a logical volune: %s'
+                               % (uuidornameorlabel, lv_x))
+            for partition, partdata in six.iteritems(self._img_info['partitions']):
+                if self.skip_partition(partdata):
+                    _logger.debug('Skipping %s' % partition)
+                elif partition == uuidornameorlabel:
+                    part = partition
+                    mount = partdata['mountpoint']
+                    _logger.debug('%s found in %s' % (lv_x, partition))
+                    break
+            _logger.debug('break..LVM')
+        else:
+            _logger.error('Unsupported fstab entry: %s' % uuidornameorlabel)
+            part = 'na'
+            mount = 'na'
+
+        _logger.debug('part found: %s' % part)
+        return part, mount
+
+    def get_grub_data(self, rootdir):
+        """
+        Collect data related to boot and grub.
+        Parameters:
+        ----------
+            rootdir: str
+                Mountpoint of the root partition.
+
+        Returns
+        -------
+            list: List with relevant data from the grub config file:
+               boot type, BIOS or EFI,
+               boot instructions
+        """
+        #
+        # find grub.cfg, grub.conf, ...
+        grubconflist = ['grub.cfg', 'grub.conf']
+        grub_cfg_path = None
+        for grubname in grubconflist:
+            for grubroot in [rootdir + '/boot',
+                             rootdir + '/grub',
+                             rootdir + '/grub2']:
+                _logger.debug('Looking for %s in %s' % (grubname, grubroot))
+                grubconf = migrate_utils.exec_search(grubname, grubroot)
+                if grubconf is not None:
+                    grub_cfg_path = grubconf
+                    _logger.debug('Found grub config file: %s' % grub_cfg_path)
+                    break
+                else:
+                    _logger.debug('No grub config file in %s' % grubroot)
+        #
+        # if no grub config file is found, need to quit.
+        if grub_cfg_path is None:
+            raise OciMigrateException('No grub config file found in %s' % self._fn)
+        else:
+            migrate_tools.result_msg(msg='Grub config file: %s' % grub_cfg_path,
+                                 result=True)
+        #
+        # investigate grub cfg path: contents of EFI/efi directory.
+        if 'EFI' in grub_cfg_path.split('/'):
+            self._img_info['boot_type'] = 'UEFI'
+        else:
+            self._img_info['boot_type'] = 'BIOS'
+        # _logger.debug('Image boot type is %s' % self._img_info[
+        # 'boot_type'])
+        migrate_tools.result_msg(msg='Image boot type: %s' % self._img_info[
+            'boot_type'])
+        #
+        # get grub config contents
+        grubdata = list()
+        grub2 = False
+        grubentry = dict()
+        _logger.debug('Initialised grub structure')
+        try:
+            #
+            # check for grub2 data
+            mentry = False
+            with open(grub_cfg_path, 'rb') as f:
+                for ffsline in f:
+                    fsline = ffsline.strip()
+                    if len(fsline.split()) > 0:
+                        _logger.debug('%s' % fsline)
+                        if fsline.split()[0] == 'menuentry':
+                            mentry = True
+                            grub2 = True
+                            if grubentry:
+                                grubdata.append(grubentry)
+                            grubentry = {'menuentry': [fsline]}
+                            _logger.debug('grub line: %s' % fsline)
+                        elif fsline.split()[0] == 'search':
+                            if mentry:
+                                grubentry['menuentry'].append(fsline)
+                                _logger.debug('Grub line: %s'
+                                                   % grubentry['menuentry'])
+                            else:
+                                _logger.debug('Not a menuentry, '
+                                                   'skipping %s' % fsline)
+                        else:
+                            _logger.debug('Skipping %s' % fsline)
+            if grubentry:
+                grubdata.append(grubentry)
+        except Exception as e:
+            _logger.error('Errors during reading %s: %s'
+                               % (grub_cfg_path, str(e)))
+            raise OciMigrateException('Errors during reading %s: %s'
+                                      % (grub_cfg_path, str(e)))
+        if grub2:
+            _logger.debug('Found grub2 configuration file.')
+            migrate_tools.result_msg(msg='Found grub2 configuration file',
+                                 result=True)
+        else:
+            migrate_tools.result_msg(msg='Found grub configuration file',
+                                 result=True)
+            try:
+                #
+                # check for grub data
+                with open(grub_cfg_path, 'rb') as f:
+                    for ffsline in f:
+                        fsline = ffsline.strip()
+                        if len(fsline.split()) > 0:
+                            _logger.debug('%s' % fsline)
+                            if fsline.split()[0] == 'title':
+                                if grubentry:
+                                    grubdata.append(grubentry)
+                                grubentry = {'title': [fsline]}
+                                _logger.debug('grub line: %s' % fsline)
+                            elif fsline.split()[0] == 'kernel':
+                                grubentry['title'].append(fsline)
+                                _logger.debug('grub line: %s'
+                                                   % grubentry['title'])
+                            else:
+                                _logger.debug('skipping %s' % fsline)
+                if grubentry:
+                    grubdata.append(grubentry)
+            except Exception as e:
+                _logger.error('Errors during reading %s: %s'
+                                   % (grub_cfg_path, str(e)))
+                raise OciMigrateException('Errors during reading %s: %s'
+                                          % (grub_cfg_path, str(e)))
+
+        return grubdata
+
+    def get_os_release(self):
+        """
+        Collect information on the linux operating system and release.
+        Currently is only able to handle linux type os.
+
+        Returns
+        -------
+            dict: Dictionary containing the os and version data on success,
+            empty dict otherwise.
+        """
+        _logger.debug('Collection os data, looking in %s'
+                           % self._mountpoints)
+        osdict = dict()
+        #
+        # hostnamectl is a systemd command, not available in OL/RHEL/CentOS 6
+        try:
+            for mnt in self._mountpoints:
+                osdata = migrate_utils.exec_search('os-release', mnt)
+                if osdata is not None:
+                    with open(osdata, 'rb') as f:
+                        osreleasedata = [line.strip()
+                                         for line in f.read().splitlines()
+                                         if '=' in line]
+                    osdict = dict([re.sub(r'"', '', kv).split('=')
+                                   for kv in osreleasedata])
+                    break
+                else:
+                    _logger.debug('os-release not found in %s' % mnt)
+        except Exception as e:
+            _logger.error('Failed to collect os data: %s' % str(e),
+                               exc_info=True)
+        _logger.debug('os data: %s' % osdict)
+        return osdict
+
+    def get_fstab(self, fstabfile):
+        """
+        Read and analyse fstab file.
+
+        Parameters
+        ----------
+            fstabfile: str
+                Full path of the fstab file.
+
+        Returns
+        -------
+            list: Relevant lines of fstab files as list.
+        """
+        fstabdata = list()
+        # fstabfile = self._img_info['rootmnt'][1] + '/etc/fstab'
+        _logger.debug('Fstabfile: %s' % fstabfile)
+        try:
+            with open(fstabfile, 'rb') as f:
+                for fsline in f:
+                    if '#' not in fsline and len(fsline.split()) > 5:
+                        # fsline[0] != '#' ????
+                        fstabdata.append(fsline.split())
+                        migrate_tools.result_msg(msg='%s' % fsline.split())
+                    else:
+                        _logger.debug('skipping %s' % fsline)
+        except Exception as e:
+            _logger.error('Problem reading %s: %s' % (fstabfile, str(e)))
+        return fstabdata
+
+    def generic_prereq_check(self):
+        """
+        Verify the generic prequisites.
+        Returns
+        -------
+            bool: True or False.
+            str : The eventual message.
+        """
+        thispass = True
+        failmsg = ''
+        #
+        # BIOS boot
+        if 'boot_type' in self._img_info:
+            if self._img_info['boot_type'] in get_config_data('valid_boot_types'):
+                _logger.debug('Boot type is %s, ok'
+                                   % self._img_info['boot_type'])
+                migrate_tools.result_msg(msg='Boot type is %s, ok'
+                                         % self._img_info['boot_type'],
+                                     result=True)
+            else:
+                thispass = False
+                _logger.debug('Boot type %s is not a valid boot '
+                                   'type. ' % self._img_info['boot_type'])
+                failmsg += '\n  - Boot type %s is not a valid boot ' \
+                           'type. ' % self._img_info['boot_type']
+        else:
+            thispass = False
+            failmsg += '\n  - Boot type not found.'
+        #
+        # MBR
+        if 'mbr' in self._img_info:
+            if self._img_info['mbr']['valid']:
+                _logger.debug('The image %s contains a '
+                                   'valid MBR.' % self._img_info['img_name'])
+                migrate_tools.result_msg(msg='The image %s contains a valid MBR.'
+                                         % self._img_info['img_name'],
+                                     result=True)
+            else:
+                thispass = False
+                _logger.debug('The image %s does not contain a '
+                                   'valid MBR.' % self._img_info['img_name'])
+                failmsg += '\n  - The image %s does not contain a ' \
+                           'valid MBR.' % self._img_info['img_name']
+        #
+        # 1 disk: considering only 1 image file, representing 1 virtual disk,
+        # implicitly.
+        #
+        # Bootable
+            partitiontable = self._img_info['mbr']['partition_table']
+            bootflag = False
+            for i in range(0, len(partitiontable)):
+                if partitiontable[i]['boot']:
+                    bootflag = True
+                    _logger.debug('The image %s is bootable'
+                                       % self._img_info['img_name'])
+                    migrate_tools.result_msg(msg='The image %s is bootable'
+                                             % self._img_info['img_name'],
+                                         result=True)
+            if not bootflag:
+                thispass = False
+                _logger.error('The image %s is not bootable'
+                                       % self._img_info['img_name'])
+                failmsg += '\n  - The image %s is not bootable.' \
+                           % self._img_info['img_name']
+        else:
+            thispass = False
+            failmsg += '\n  - MBR not found.'
+        #
+        # Everything needed to boot in this image? Compairing fstab with
+        # partition data.
+        if 'fstab' in self._img_info:
+            fstabdata = self._img_info['fstab']
+            partitiondata = self._img_info['partitions']
+
+            fstab_pass = True
+            for line in fstabdata:
+                part_pass = False
+                _logger.debug('Fstabline: %s' % line)
+                if 'UUID' in line[0]:
+                    uuid_x = re.split('\\bUUID=\\b', line[0])[1]
+                    for _, part in six.iteritems(partitiondata):
+                        _logger.debug('partition: %s' % part)
+                        if 'ID_FS_UUID' in part:
+                            if part['ID_FS_UUID'] == uuid_x:
+                                part_pass = True
+                                migrate_tools.result_msg(
+                                    msg='Found %s in partition table.'
+                                        % uuid_x, result=True)
+                                break
+                elif 'LABEL' in line[0]:
+                    label_x = re.split('\\bLABEL=\\b', line[0])[1]
+                    for _, part in six.iteritems(partitiondata):
+                        _logger.debug('partition: %s' % part)
+                        if 'ID_FS_LABEL' in part:
+                            if part['ID_FS_LABEL'] == label_x:
+                                part_pass = True
+                                migrate_tools.result_msg(
+                                    msg='Found %s in partition table.'
+                                        % label_x, result=True)
+                                break
+                elif 'mapper' in line[0]:
+                    lv_x = re.split('\\bmapper/\\b', line[0])[1]
+                    for part, _ in six.iteritems(partitiondata):
+                        _logger.debug('partition: %s' % part)
+                        if lv_x in part:
+                            part_pass = True
+                            migrate_tools.result_msg(
+                                msg='Found %s in partition table.'
+                                    % lv_x, result=True)
+                            break
+                elif '/dev/' in line[0]:
+                    _logger.critical('Device name %s in fstab are '
+                                          'not supported.' % line[0])
+                else:
+                    part_pass = True
+                    migrate_tools.result_msg(msg='Unrecognised: %s, ignoring.'
+                                         % line[0], result=True)
+
+                if not part_pass:
+                    fstab_pass = False
+                    break
+
+            if not fstab_pass:
+                thispass = False
+                failmsg += '\n  - fstab file refers to unsupported or ' \
+                           'unreachable partitions.'
+        else:
+            thispass = False
+            failmsg += '\n  - fstab file not found.'
+        #
+        # boot using LVM or UUID
+        if 'grubdata' in self._img_info:
+            grubdata = self._img_info['grubdata']
+        #
+        # grub: 'root=UUID'
+        # grub2: '--fs-uuid'
+            grub_fail = 0
+            grub_l = 0
+            for entry in grubdata:
+                for key in entry:
+                    for l in entry[key]:
+                        l_split = l.split()
+                        if l_split[0] == 'search':
+                            grub_l += 1
+                            if '--fs-uuid' not in l_split:
+                                _logger.error('grub2 line ->%s<- does not '
+                                                   'specify boot partition '
+                                                   'via UUID.' % l)
+                                grub_fail += 1
+                            else:
+                                migrate_tools.result_msg(
+                                    msg='grub2 line ->%s<- specifies boot '
+                                        'partition via UUID.' % l)
+                        elif l_split[0] == 'kernel':
+                            grub_l += 1
+                            if len([a for a in l_split
+                                    if any(b in a
+                                           for b in ['root=UUID='])]) == 0:
+                                _logger.error('grub line ->%s<- does not '
+                                                   'specify boot partition '
+                                                   'via UUID.' % l)
+                                grub_fail += 1
+                            else:
+                                migrate_tools.result_msg(
+                                    msg='grub line ->%s<- specifies boot '
+                                        'partition via UUID.' % l,
+                                    result=True)
+                        else:
+                            _logger.debug('skipping %s' % l_split)
+            if grub_l == 0:
+                thispass = False
+                failmsg += '\n  - No boot entry found in grub/gru2 config file.'
+            elif grub_fail > 0:
+                thispass = False
+                failmsg += '\n  - grub config file does not guarantee booting ' \
+                           'using UUID'
+            else:
+                _logger.debug('Grub config file ok.')
+        else:
+            thispass = False
+            failmsg += '\n  - Grub config file not found.'
+        #
+        # OS
+        if 'osinformation' in self._img_info:
+            osdata = self._img_info['osinformation']
+            os_pass = False
+            os_name = 'notsupportedos'
+            for k, v in six.iteritems(osdata):
+                _logger.debug('%s %s' % (k, v))
+                if k.upper() == 'NAME':
+                    vu = v.upper().strip()
+                    os_name = v
+                    _logger.debug('OS name: %s' % vu)
+                    if vu in get_config_data('valid_os'):
+                        migrate_tools.result_msg(msg='OS is a %s: valid' % v,
+                                             result=True)
+                        os_pass = True
+                    else:
+                        self._logger.error('->OS<- %s is not supported.' % v)
+            if not os_pass:
+                thispass = False
+                failmsg += '\n  - OS %s is not supported' % os_name
+        else:
+            thispass = False
+            failmsg += '\n  - OS release file not found.'
+
+        return thispass, failmsg

--- a/lib/oci_utils/migrate/imgdevice.py
+++ b/lib/oci_utils/migrate/imgdevice.py
@@ -1058,8 +1058,6 @@ class DeviceData(object):
             self._img_info['boot_type'] = 'UEFI'
         else:
             self._img_info['boot_type'] = 'BIOS'
-        # _logger.debug('Image boot type is %s' % self._img_info[
-        # 'boot_type'])
         migrate_tools.result_msg(msg='Image boot type: %s' % self._img_info[
             'boot_type'])
         #
@@ -1206,7 +1204,7 @@ class DeviceData(object):
         Returns
         -------
             bool: True or False.
-            str : The eventual message.
+            str : The eventual fail message.
         """
         thispass = True
         failmsg = ''

--- a/lib/oci_utils/migrate/migrate_tools.py
+++ b/lib/oci_utils/migrate/migrate_tools.py
@@ -1,0 +1,536 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+""" Module containing generic operation methods.
+"""
+import logging
+import os
+import six
+import stat
+import subprocess
+import sys
+import threading
+import time
+
+from datetime import datetime
+from oci_utils.migrate.exception import NoSuchCommand
+from oci_utils.migrate.exception import OciMigrateException
+
+_logger = logging.getLogger('oci-utils.migrate-tools')
+debugflag = False
+verboseflag = False
+thistime = datetime.now().strftime('%Y%m%d%H%M')
+resultfilename = '/tmp/oci_image_migrate_result.dat'
+nameserver = '8.8.8.8'
+migrate_preparation = True
+migrate_non_upload_reason = ''
+
+
+def error_msg(msg=None):
+    """
+    GT debug message
+
+    Parameters
+    ----------
+    msg: str
+        Eventual message.
+
+    Returns
+    -------
+        No return value
+    """
+    _logger.error('%s' % msg)
+    if msg is not None:
+        msg = '  *** ERROR *** %s' % msg
+    else:
+        msg = '  *** ERROR *** Unidentified error.'
+    sys.stderr.write('%s' % msg)
+    sys.stderr.flush()
+    result_msg(msg=msg)
+    time.sleep(1)
+
+
+def result_msg(msg, flags='a', result=False):
+    """
+    Write information to the log file, the result file and the console if the
+    result flag is set.
+
+    Parameters
+    ----------
+    msg: str
+        The message.
+    flags: str
+        The flags for the open file command.
+    result: bool
+        Flag, write to console if True.
+
+    Returns
+    -------
+        No return value.
+    """
+    _logger.debug('%s' % msg)
+    try:
+        with open(resultfilename, flags) as f:
+            f.write('  %s\n' % msg)
+    except Exception as e:
+        _logger.error('Failed to write to %s: %s' % (resultfilename, str(e)))
+    if result:
+        if msg is not None:
+            print('  %s' % msg)
+        else:
+            print('  Just mentioning I am here.')
+
+
+def is_root():
+    """
+    Verify is operator is the root user.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    if os.getuid() == 0:
+        return True
+    else:
+        return False
+
+
+def thissleep(secs, msg=None):
+    """
+    Sleep for secs seconds.
+
+    Parameters
+    ----------
+    secs: float
+        Time to sleep.
+    msg: str
+        Eventual message to comment on sleep.
+
+    Returns
+    -------
+        No return value.
+    """
+    secint = 0.3
+    sectot = 0.0
+    if msg is not None:
+        sys.stdout.write('\n  %s' % msg)
+    while True:
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        time.sleep(secint)
+        sectot += secint
+        if sectot > secs:
+            break
+    print('\n')
+
+
+def dir_exists(dirpath):
+    """
+    Verify if the path exists and is a directory.
+
+    Parameters
+    ----------
+    dirpath: str
+        The full path of the directory.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    _logger.debug('Directory full path name: %s' % dirpath)
+    #
+    try:
+        return stat.S_ISDIR(os.stat(dirpath).st_mode)
+    except Exception as e:
+        _logger.debug('Path %s does not exist or is not a valid directory: %s' %
+                     (dirpath, str(e)))
+        return False
+
+
+def file_exists(filepath):
+    """
+    Verify if the file exists and is a regular file.
+
+    Parameters
+    ----------
+    filepath: str
+        The full path of the file.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    _logger.debug('File full path name: %s' % filepath)
+    #
+    try:
+        return stat.S_ISREG(os.stat(filepath).st_mode)
+    except Exception as e:
+        _logger.debug('Path %s does not exist or is not a valid regular file: '
+                     '%s' % (filepath, str(e)))
+        return False
+
+
+def link_exists(linkpath):
+    """
+    Verify if the linkpath exists and is a symbolic link.
+
+    Parameters
+    ----------
+    linkpath: str
+        The full path of the link.
+
+    Returns
+    -------
+        bool: True on success, false otherwise.
+    """
+    _logger.debug('Link full path name: %s' % linkpath)
+    try:
+        return os.path.islink(linkpath)
+    except Exception as e:
+        _logger.debug('%s is not a symbolic link or does not exist: %s' %
+                     (linkpath, str(e)))
+        return False
+
+
+def get_magic_data(image):
+    """
+    Collect the magic number of the image file.
+
+    Parameters
+    ----------
+    image: str
+        Full path of the image file.
+
+    Returns
+    -------
+        str: Magic string on success, None otherwise.
+    """
+    magic_hex = None
+    bytes_to_hex_str = lambda b: ''.join('%02x' % i for i in six.iterbytes(b))
+    try:
+        with open(image, 'rb') as f:
+            magic = f.read(4)
+            magic_hex = bytes_to_hex_str(magic)
+            _logger.debug('Image magic number: %8s' % magic_hex)
+    except Exception as e:
+        _logger.critical('Image %s is not accessible: 0X%s' % (image, str(e)))
+    return magic_hex
+
+
+def exec_exists(executable):
+    """
+    Verify if executable exists in path.
+
+    Parameters
+    ----------
+    executable: str
+        The file to be tested.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+
+    """
+    return subprocess.call(['which', executable],
+                           stdout=open(os.devnull, 'wb'),
+                           stderr=open(os.devnull, 'wb'),
+                           shell=False) == 0
+
+
+def exec_rename(fromname, toname):
+    """
+    Renames a file, symbolic link or directory.
+
+    Parameters
+    ----------
+    fromname: str
+        Full path of the original file.
+    toname: str
+        The new name as full path.
+
+    Returns
+    -------
+        bool: True on success, raises an exception on failure.
+    """
+    try:
+        #
+        # delete to_ if already exists
+        #
+        # if file or directory
+        if os.path.exists(toname):
+            _logger.debug('%s already exists' % toname)
+            if os.path.isfile(toname):
+                os.remove(toname)
+            elif os.path.isdir(toname):
+                os.rmdir(toname)
+            else:
+                _logger.error('Failed to remove %s.' % toname)
+        if os.path.islink(toname):
+            _logger.debug('%s already exists as a symbolic link.' % toname)
+            if os.unlink(toname):
+                _logger.debug('Removed symbolic link %s' % toname)
+            else:
+                _logger.error('Failed to remove symbolic link %s' % toname)
+
+        if os.path.exists(fromname) or os.path.islink(fromname):
+            _logger.debug('%s exists and is a file.' % fromname)
+            os.rename(fromname, toname)
+            _logger.debug('Renamed %s to %s.' % (fromname, toname))
+            return True
+        else:
+            _logger.error('%s does not exists' % fromname)
+
+    except Exception as e:
+        _logger.error('Failed to rename %s to %s: %s' % (fromname, toname, str(e)))
+        raise OciMigrateException('Failed to rename %s to %s: %s'
+                                  % (fromname, toname, str(e)))
+    return False
+
+
+def run_popen_cmd(command):
+    """
+    Execute an os command and collect stdout and stderr.
+
+    Parameters
+    ----------
+    command: list
+        The os command and its arguments.
+
+    Returns
+    -------
+        <type>: The output of the command on success, raises an exception on
+        failure.
+    """
+    _logger.debug('%s command' % command)
+    if exec_exists(command[0]):
+        _logger.debug('running %s' % command)
+        try:
+            thisproc = subprocess.Popen(command,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
+            output, error = thisproc.communicate()
+            retcode = thisproc.returncode
+            _logger.debug('return code for %s: %s' % (command, retcode))
+            if retcode != 0:
+                if error:
+                    _logger.debug('Error occured while '
+                                 'running %s: %s - %s'
+                                 % (command, retcode, error), exc_info=True)
+                raise OciMigrateException('Error encountered while '
+                                          'running %s: %s - %s'
+                                          % (command, retcode, error))
+            if output:
+                return output
+        except OSError as oserr:
+            raise OciMigrateException('OS error encountered while '
+                                      'running %s: %s' % (command, str(oserr)))
+        except Exception as e:
+            raise OciMigrateException('Error encountered while running %s: %s'
+                                      % (command, str(e)))
+    else:
+        _logger.critical('%s not found.' % command[0])
+        raise NoSuchCommand(command[0])
+
+
+def get_nameserver():
+    """
+    Get the nameserver definitions.
+
+    Returns
+    -------
+    bool: True on success, False otherwise.
+    """
+    global nameserver
+    _logger.debug("Getting nameservers.")
+    dnslist = []
+    cmd = ['nmcli', 'dev', 'show']
+    try:
+        nmlist = run_popen_cmd(cmd).decode().split('\n')
+        for nmitem in nmlist:
+            if 'DNS' in nmitem.split(':')[0]:
+                dnslist.append(nmitem.split(':')[1].lstrip().rstrip())
+        nameserver = dnslist[0]
+        _logger.debug('Nameserver set to %s' % nameserver)
+        return True
+    except Exception as e:
+        _logger.error('Failed to identify nameserver: %s.' % str(e))
+        return False
+
+
+def set_nameserver():
+    """
+    Setting temporary nameserver.
+
+    Returns
+    -------
+    bool: True on success, False otherwise.
+    """
+    # rename eventual existing resolv.conf
+    resolvpath = '/etc/resolv.conf'
+    try:
+        #
+        # save current
+        if os.path.isfile(resolvpath) \
+                or os.path.islink(resolvpath) \
+                or os.path.isdir(resolvpath):
+            exec_rename(resolvpath, resolvpath + '_' + thistime)
+        else:
+            _logger.debug('No %s found' % resolvpath)
+        #
+        # write new
+        with open(resolvpath, 'wb') as f:
+            f.writelines('nameserver %s\n' % nameserver)
+        return True
+    except Exception as e:
+        error_msg('Failed to set nameserver: %s'
+                  '\n  continuing but might cause issues installing cloud-init.'
+                  % str(e))
+        return False
+
+
+def restore_nameserver():
+    """
+    Restore nameserver configuration.
+
+    Returns
+    -------
+    bool: True on success, False otherwise.
+    """
+    resolvpath = '/etc/resolv.conf'
+    try:
+        #
+        # save used one
+        if file_exists(resolvpath):
+            exec_rename(resolvpath, resolvpath + '_temp_' + thistime)
+        else:
+            _logger.debug('No %s found.' % resolvpath)
+        #
+        # restore original one
+        if file_exists(resolvpath + '_' + thistime):
+            exec_rename(resolvpath + '_' + thistime, resolvpath)
+        else:
+            _logger.debug('No %s found.' % resolvpath + '_' + thistime)
+        return True
+    except Exception as e:
+        error_msg('Failed to restore nameserver: %s'
+                  '\n  continuing but might cause issues installing cloud-init.'
+                  % str(e))
+        return False
+
+
+def isthreadrunning(threadid):
+    """
+    Verify if thread is active.
+
+    Parameters
+    ----------
+    threadid: thread
+        The thread to test.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    _logger.debug('Testing thread.')
+    if threadid in threading.enumerate():
+        return True
+    else:
+        return False
+
+
+class ProgressBar(threading.Thread):
+    """
+    Class to generate an indication of progress, does not actually
+    measure real progress, just shows the process is not hanging.
+    """
+    _default_progress_chars = ['-', '/', '|', '\\']
+
+    def __init__(self, bar_length, progress_interval, progress_chars=None):
+        """
+        Progressbar initialisation.
+
+        Parameters:
+        ----------
+        bar_length: int
+            Length of the progress bar.
+        progress_interval: float
+            Interval in sec of change.
+        progress_chars: list
+            List of char or str to use; the list is mirrored before use.
+        """
+        self._stopthread = threading.Event()
+        threading.Thread.__init__(self)
+        self._bar_len = bar_length
+        self._prog_int = progress_interval
+        if progress_chars is None:
+            self.prog_chars = self._default_progress_chars
+        else:
+            #
+            # compose list of characters to use in progress bar.
+            self.prog_chars = progress_chars
+            prog_char_len = len(self.progress_chars)
+            for i in range(1, prog_char_len-1):
+                self.prog_chars.append(progress_chars[prog_char_len-i-1])
+        self.stopthis = False
+
+    def run(self):
+        """
+        Execute the progress bar.
+
+        Returns
+        -------
+            No return value.
+        """
+        prog_char_len = len(self.prog_chars)
+        prog_bar_len = len(self.prog_chars[0]) * self._bar_len
+        empty = ' '*prog_bar_len
+        sys.stdout.write('  [%s]\r  [' % empty)
+        sys.stdout.flush()
+        i = 0
+        j = i%prog_char_len
+        k = 0
+        while True:
+            sys.stdout.write('%s' % self.prog_chars[j])
+            sys.stdout.flush()
+            k += 1
+            if k == self._bar_len:
+                k = 0
+                i += 1
+                j = i%prog_char_len
+                sys.stdout.write(']\r  [')
+                sys.stdout.flush()
+            time.sleep(self._prog_int)
+            if self.stopthis:
+                sys.stdout.write('\r  [%s]\r  [' % empty)
+                sys.stdout.flush()
+                break
+
+    def stop(self):
+        """
+        Notify thread to stop the progress bar.
+
+        Returns
+        -------
+            No return value.
+        """
+        self.stopthis = True
+        self.join()
+
+    def join(self, timeout=None):
+        """
+        Terminate the thread.
+
+        Parameters
+        ----------
+        timeout: float
+            Time to wait if set.
+
+        Returns
+        -------
+            No return value.
+        """
+        self._stopthread.set()
+        threading.Thread.join(self, timeout)

--- a/lib/oci_utils/migrate/migrate_utils.py
+++ b/lib/oci_utils/migrate/migrate_utils.py
@@ -158,36 +158,42 @@ def leave_chroot(root2return):
         OciMigrateException('Failed to return from chroot: %s' % str(e))
 
 
-def exec_search(thisfile, rootdir='/'):
+def exec_search(thisname, rootdir='/', dirnames=False):
     """
     Find the filename in the rootdir tree.
 
     Parameters
     ----------
-    thisfile: str
+    thisname: str
         The filename to look for.
     rootdir: str
         The directory to start from, default is root.
+    dirnames: bool
+        If True, also consider directory names.
 
     Returns
     -------
         str: The full path of the filename if found, None otherwise.
     """
-    _logger.debug('Looking for %s in %s' % (thisfile, rootdir))
+    _logger.debug('Looking for %s in %s' % (thisname, rootdir))
     migrate_tools.result_msg(msg='Looking for %s in %s, might take a while.'
-                             % (thisfile, rootdir))
+                             % (thisname, rootdir))
     try:
         for thispath, directories, files in os.walk(rootdir):
             # _logger.debug('%s %s %s' % (thispath, directories, files))
-            if thisfile in files:
+            if thisname in files:
                 _logger.debug('Found %s'
-                             % os.path.join(rootdir, thispath, thisfile))
-                return os.path.join(rootdir, thispath, thisfile)
+                             % os.path.join(rootdir, thispath, thisname))
+                return os.path.join(rootdir, thispath, thisname)
+            if dirnames and thisname in directories:
+                _logger.debug('Found %s as directory.'
+                             % os.path.join(rootdir, thispath, thisname))
+                return os.path.join(rootdir, thispath, thisname)
     except Exception as e:
         _logger.error('Error while looking for %s: %s'
-                     % (thisfile, str(e)))
+                     % (thisname, str(e)))
         raise OciMigrateException('Error while looking for %s: %s'
-                                  % (thisfile, str(e)))
+                                  % (thisname, str(e)))
     return None
 
 

--- a/lib/oci_utils/migrate/migrate_utils.py
+++ b/lib/oci_utils/migrate/migrate_utils.py
@@ -1,0 +1,1649 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module containing generic data and code with respect to the migration to the
+Oracle Cloud Infrastructure.
+"""
+import json
+import logging
+import os
+import pkgutil
+import re
+import shutil
+import six
+import subprocess
+import yaml
+import sys
+import time
+
+from functools import wraps
+from glob import glob
+from oci_utils.impl.sudo_utils import call as run_call_cmd
+from oci_utils.migrate import get_config_data
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate import pause_msg
+from oci_utils.migrate.exception import NoSuchCommand
+from oci_utils.migrate.exception import OciMigrateException
+from six.moves import configparser
+
+_logger = logging.getLogger('oci-utils.migrate-utils')
+ConfigParser = configparser.ConfigParser
+
+gigabyte = 2**30
+rmmod_max_count = 4
+qemu_max_count = 2
+#
+# the root for loopback mounts of partitions and logical volumes.
+loopback_root = '/mnt'
+#
+# the root of the migrate related packages.
+module_home = 'oci_utils.migrate'
+
+
+def state_loop(maxloop, intsec=1):
+    """
+    Decorator to allow a function to retry maxloop times with an interval of
+    intsec before failing.
+
+    Parameters
+    ----------
+    maxloop: int
+        Maximum tries.
+    intsec: int
+        Interval in seconds.
+
+    Returns
+    -------
+        Method return value.
+    """
+    def wrap(func):
+        @wraps(func)
+        def loop_func(*args, **kwargs):
+            funcret = False
+            for i in range(0, maxloop):
+                _logger.debug('State loop %d' % i)
+                try:
+                    funcret = func(*args, **kwargs)
+                    return funcret
+                except Exception as e:
+                    _logger.debug('Failed, sleeping for %d sec: %s'
+                                 % (intsec, str(e)))
+                    if i == maxloop - 1:
+                        raise OciMigrateException('State Loop exhausted: %s'
+                                                  % str(e))
+                    time.sleep(intsec)
+        return loop_func
+    return wrap
+
+
+def enter_chroot(newroot):
+    """
+    Execute the chroot command.
+
+    Parameters
+    ----------
+        newroot: str
+            Full path of new root directory.
+
+    Returns
+    -------
+        file descriptor, str: The file descriptor of the current root on
+        success, path to restore; raises an exception on failure.
+    """
+    root2return = -1
+    try:
+        #
+        # change root
+        root2return = os.open('/', os.O_RDONLY)
+        os.chdir(newroot)
+        os.chroot(newroot)
+        _logger.debug('Changed root to %s.' % newroot)
+    except Exception as e:
+        _logger.error('Failed to change root to %s: %s' % (newroot, str(e)))
+        #
+        # need to return env.
+        if root2return > 0:
+            os.fchdir(root2return)
+            os.chroot('.')
+            os.close(root2return)
+        raise OciMigrateException('Failed to change root to %s: %s'
+                                  % (newroot, str(e)))
+    try:
+        #
+        # adjust PATH to make sure.
+        currentpath = os.environ['PATH']
+        newpath = currentpath.replace('/bin', '')\
+                      .replace('/usr/bin', '')\
+                      .replace('/sbin', '')\
+                      .replace('/usr/sbin', '')\
+                      .replace('/usr/local/sbin', '')\
+                      .replace('::', ':') \
+                  + ':/root/bin:/bin:/usr/bin:/usr/sbin:/usr/local/sbin:/sbin'
+        os.environ['PATH'] = newpath
+        _logger.debug('Set path to %s' % newpath)
+        return root2return, currentpath
+    except Exception as e:
+        _logger.error('Failed to set path to %s: %s' % (newpath, str(e)))
+        raise OciMigrateException('Failed to set path to %s: %s'
+                                  % (newpath, str(e)))
+
+
+def leave_chroot(root2return):
+    """
+    Leave a chroot environment and return to another one.
+
+    Parameters
+    ----------
+    root2return: file descriptor
+        The file descriptor of the root to return to.
+
+    Returns
+    -------
+        bool: True on success, raises exception on failure.
+    """
+    try:
+        #
+        # leave chroot
+        os.fchdir(root2return)
+        os.chroot('.')
+        os.close(root2return)
+        _logger.debug('Left change root environment.')
+        return True
+    except Exception as e:
+        _logger.error('Failed to return from chroot: %s' % str(e))
+        OciMigrateException('Failed to return from chroot: %s' % str(e))
+
+
+def exec_search(thisfile, rootdir='/'):
+    """
+    Find the filename in the rootdir tree.
+
+    Parameters
+    ----------
+    thisfile: str
+        The filename to look for.
+    rootdir: str
+        The directory to start from, default is root.
+
+    Returns
+    -------
+        str: The full path of the filename if found, None otherwise.
+    """
+    _logger.debug('Looking for %s in %s' % (thisfile, rootdir))
+    migrate_tools.result_msg(msg='Looking for %s in %s, might take a while.'
+                             % (thisfile, rootdir))
+    try:
+        for thispath, directories, files in os.walk(rootdir):
+            # _logger.debug('%s %s %s' % (thispath, directories, files))
+            if thisfile in files:
+                _logger.debug('Found %s'
+                             % os.path.join(rootdir, thispath, thisfile))
+                return os.path.join(rootdir, thispath, thisfile)
+    except Exception as e:
+        _logger.error('Error while looking for %s: %s'
+                     % (thisfile, str(e)))
+        raise OciMigrateException('Error while looking for %s: %s'
+                                  % (thisfile, str(e)))
+    return None
+
+
+@state_loop(rmmod_max_count)
+def exec_rmmod(module):
+    """
+    Removes a module.
+
+    Parameters
+    ----------
+    module: str
+        The module name.
+
+    Returns
+    -------
+        bool: True
+    """
+    cmd = ['rmmod']
+    cmd.append(module)
+    try:
+        rmmod_result = subprocess.check_call(cmd, stdout=open(os.devnull, 'wb'),
+                                             stderr=open(os.devnull, 'wb'),
+                                             shell=False)
+        if rmmod_result == 0:
+            _logger.debug('Successfully removed %s' % module)
+        else:
+            _logger.error('Error removing %s, exit code %s, ignoring.'
+                         % (cmd, str(rmmod_result)))
+    except Exception as e:
+        _logger.debug('Failed: %s, ignoring.' % str(e))
+    #
+    # ignoring eventual errors, which will be caused by module already removed.
+    return True
+
+
+@state_loop(qemu_max_count)
+def exec_qemunbd(qemunbd_args):
+    """
+    Execute a qemu-nbd command.
+
+    Parameters
+    ----------
+    qemunbd_args: list
+        The list of arguments for qemu-nbd.
+
+    Returns
+    -------
+        int: 0 on success, non-zero return value otherwise.
+
+    """
+    cmd = ['qemu-nbd'] + qemunbd_args
+    pause_msg(cmd)
+    try:
+        qemunbd_res = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('success: %s' % qemunbd_res)
+        return qemunbd_res
+    except Exception as e:
+        _logger.error('%s command failed: %s' % (cmd, str(e)))
+        raise OciMigrateException('\n%s command failed: %s' % (cmd, str(e)))
+
+
+def exec_mkdir(dirname):
+    """
+    Create a directory.
+
+    Parameters
+    ----------
+    dirname: str
+        The full path of the directory.
+
+    Returns
+    -------
+        bool:
+           True on success, False otherwise.
+    """
+    _logger.debug('Creating %s.' % dirname)
+    try:
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+        else:
+            _logger.debug('Directory %s already exists' % dirname)
+    except Exception as e:
+        raise OciMigrateException(str(e))
+
+
+@state_loop(qemu_max_count)
+def exec_rmdir(dirname):
+    """
+    Create a directory.
+
+    Parameters
+    ----------
+    dirname: str
+        The full path of the directory.
+
+    Returns
+    -------
+        bool:
+           True on success, raises an exception otherwise.
+    """
+    _logger.debug('Removing directory tree.')
+    cmd = ['rmdir']
+    try:
+        shutil.rmtree(dirname)
+        return True
+    except Exception as e:
+        raise OciMigrateException(str(e))
+
+
+@state_loop(qemu_max_count)
+def exec_blkid(blkid_args):
+    """
+    Run a blkid command.
+
+    Parameters
+    ----------
+    blkid_args: list
+        The argument list for the blkid command.
+
+    Returns
+    -------
+        dict: blkid return value on success, None otherwise.
+    """
+    cmd = ['blkid'] + blkid_args
+    try:
+        _logger.debug('running %s' % cmd)
+        pause_msg('test nbd devs')
+        blkid_res = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('success\n%s' % blkid_res)
+        return blkid_res
+    except Exception as e:
+        _logger.error('%s failed: %s' % (cmd, str(e)))
+        return None
+#        raise OciMigrateException('%s failed: %s' % (cmd, str(e)))
+
+
+def exec_lsblk(lsblk_args):
+    """
+    Run an lsblk command.
+
+    Parameters
+    ----------
+    lsblk_args: list
+        The argument list for the blkid command.
+
+    Returns
+    -------
+       dict: blkid return value on success, None otherwise.
+    """
+    cmd = ['lsblk'] + lsblk_args
+    pause_msg(cmd)
+    try:
+        _logger.debug('running %s' % cmd)
+        lsblk_res = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('success\n%s' % lsblk_res)
+        return lsblk_res
+    except Exception as e:
+        _logger.error('%s failed: %s' % (cmd, str(e)))
+        raise OciMigrateException('%s failed: %s' % (cmd, str(e)))
+
+
+@state_loop(qemu_max_count)
+def create_nbd():
+    """
+    Load nbd module
+
+    Returns
+    -------
+        bool: True on succes, False on failure.
+    """
+    cmd = ['modprobe', 'nbd', 'max_part=63']
+    try:
+        if run_call_cmd(cmd) == 0:
+            return True
+        else:
+            _logger.critical('Failed to execute %s' % cmd)
+            raise OciMigrateException('\nFailed to execute %s' % cmd)
+    except Exception as e:
+        _logger.critical('Failed: %s' % str(e))
+        return False
+
+
+@state_loop(3)
+def rm_nbd():
+    """
+    Unload kernel module nbd.
+
+    Returns
+    -------
+        bool: True on succes, False on failure.
+    """
+    modname = 'nbd'
+    if exec_rmmod(modname):
+        return True
+    else:
+        return False
+
+
+def get_free_nbd():
+    """
+    Find first free device name
+
+    Returns
+    -------
+        str: The free nbd device on success, None otherwise.
+    """
+    devpath = '/sys/class/block/nbd*'
+    try:
+        for devname in glob(devpath):
+            with open(devname + '/size', 'r') as f:
+                sz = f.readline()
+                nbdsz = int(sz)
+                if nbdsz == 0:
+                    freedev = devname.rsplit('/')[-1]
+                    return '/dev/' + freedev
+    except Exception as e:
+        _logger.critical('Failed to screen nbd devices: %s' % str(e))
+        raise OciMigrateException('\nFailed to locate a free nbd device, %s'
+                                  % str(e))
+
+
+def get_nameserver():
+    """
+    Find out if a nameserver is defined.
+
+    Returns
+    -------
+        str: The name server address on success, None otherwise.
+    """
+    cmd = ['nslookup', 'www.oracle.com']
+    nameserver = None
+    try:
+        result = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('ns data: %s' % result)
+        for resx in result.splitlines():
+            if 'Server' in resx:
+                nameserver = resx.split(':')[1]
+                break
+        return nameserver
+    except Exception as e:
+        _logger.error('Failed to identify nameserver: %s' % str(e))
+        raise OciMigrateException('Failed to identify nameserver: %s' % str(e))
+
+
+def exec_parted(devname):
+    """
+    Collect data about the device on the image using the parted utility.
+
+    Parameters
+    ----------
+    devname: str
+        The device name.
+
+    Returns
+    -------
+        dict: The device data from parted utility on success, None otherwise.
+    """
+    cmd = ['parted', devname, 'print']
+    pause_msg(cmd)
+    _logger.debug('%s' % cmd)
+    try:
+        result = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('parted: %s' % result)
+        devdata = dict()
+        for devx in result.splitlines():
+            if 'Model' in devx:
+                devdata['Model'] = devx.split(':')[1]
+            elif 'Disk' in devx:
+                devdata['Disk'] = devx.split(':')[1]
+            elif 'Partition Table' in devx:
+                devdata['Partition Table'] = devx.split(':')[1]
+            else:
+                _logger.debug('Ignoring %s' % devx)
+        _logger.debug(devdata)
+        pause_msg(devdata)
+        return devdata
+    except Exception as e:
+        _logger.error('Failed to collect parted %s device data: %s'
+                     % (devname, str(e)))
+        return None
+
+
+def exec_sfdisk(devname):
+    """
+    Collect the data about the partitions on the image file mounted on the
+    device devname using the sfdisk utility.
+
+    Parameters
+    ----------
+    devname: str
+        The device.
+
+    Returns
+    -------
+        dict: The partition data with sfdisk results on success, None otherwise.
+    """
+    cmd = ['sfdisk', '-d', devname]
+    _logger.debug('%s' % cmd)
+    pause_msg(cmd)
+    try:
+        result = migrate_tools.run_popen_cmd(cmd)
+        partdata = dict()
+        for devx in result.split('\n'):
+            if devx.startswith(devname):
+                key = devx.split(':')[0].strip()
+                migrate_tools.result_msg(msg='sfdisk partition %s' % key)
+                thispart = {'start': 0, 'size': 0, 'Id': 0, 'bootable': False}
+                val = devx.split(':')[1].split(',')
+                for it in val:
+                    if 'start' in it:
+                        x = it.split('=')[1]
+                        thispart['start'] = int(x)
+                    elif 'size' in it:
+                        x = it.split('=')[1]
+                        thispart['size'] = int(x)
+                    elif 'Id' in it:
+                        x = it.split('=')[1]
+                        thispart['Id'] = x.strip()
+                    elif 'bootable' in it:
+                        thispart['bootable'] = True
+                    else:
+                        _logger.debug('unrecognised item: %s' % val)
+                partdata[key] = thispart
+        _logger.debug(partdata)
+        return partdata
+    except Exception as e:
+        _logger.error('Failed to collect sfdisk %s partition data: %s'
+                     % (devname, str(e)))
+        return None
+
+
+@state_loop(3)
+def mount_imgfn(imgname):
+    """
+    Link vm image with an nbd device.
+
+    Parameters
+    ----------
+    imgname: str
+        Full path of the image file.
+
+    Returns
+    -------
+        str: Device name on success, raises an exception otherwise.
+    """
+    #
+    # create nbd devices
+    migrate_tools.result_msg(msg='Load nbd')
+    if not create_nbd():
+        raise OciMigrateException('Failed ot load nbd module')
+    else:
+        _logger.debug('nbd module loaded')
+    #
+    # find free nbd device
+    migrate_tools.result_msg(msg='Find free nbd device')
+    devpath = get_free_nbd()
+    _logger.debug('Device %s is free.' % devpath)
+    #
+    # link img with first free nbd device
+    migrate_tools.result_msg(msg='Mount image %s' % imgname, result=True)
+    try:
+        qemucmd = ['-c', devpath, imgname]
+        pause_msg(qemucmd)
+        z = exec_qemunbd(qemucmd)
+        migrate_tools.thissleep(4, 'Mounting %s ' % imgname)
+        _logger.debug('qemu-nbd %s succeeded' % qemucmd)
+        return devpath
+    except NoSuchCommand:
+        _logger.critical('qemu-nbd does not exist')
+        raise NoSuchCommand('qemu-nbd does not exist')
+    except Exception as e:
+        _logger.critical('\nSomething wrong with creating nbd devices: %s'
+                        % str(e))
+        raise OciMigrateException('Unable to create nbd devices: %s' % str(e))
+
+
+@state_loop(3)
+def unmount_imgfn(devname):
+    """
+    Unlink a device.
+
+    Parameters
+    ----------
+    devname: str
+        The device name
+
+    Returns
+    -------
+        bool: True on succes, raise an exception otherwise.
+    """
+    try:
+        #
+        # release device
+        qemucmd = ['-d', devname]
+        pause_msg(qemucmd)
+        z = exec_qemunbd(qemucmd)
+        _logger.debug('qemu-nbd %s succeeded: %s' % (qemucmd, str(z)))
+        #
+        # clear lvm cache, if necessary.
+        if exec_pvscan():
+            _logger.debug('lvm cache updated')
+        else:
+            _logger.error('Failed to clear LVM cache.')
+            raise OciMigrateException('Failed to clear LVM cache.')
+        #
+        # remove nbd module
+        if not rm_nbd():
+            raise OciMigrateException('Failed to remove nbd module.')
+        else:
+            _logger.debug('Successfully removed nbd module.')
+    except Exception as e:
+        _logger.critical('Something wrong with removing nbd '
+                        'devices: %s' % str(e))
+        raise OciMigrateException('\nSomething wrong with removing nbd '
+                                  'devices: %s' % str(e))
+    return True
+
+
+@state_loop(3)
+def mount_partition(devname, mountpoint=None):
+    """
+    Create the mountpoint /mnt/<last part of device specification> and mount a
+    partition on on this mountpoint.
+
+    Parameters
+    ----------
+    devname: str
+        The full path of the device.
+    mountpoint: str
+        The mountpoint, will be generated if not provided.
+
+    Returns
+    -------
+        str: The mounted partition on Success, None otherwise.
+    """
+    #
+    # create mountpoint /mnt/<devname> if not specified.
+    if mountpoint is None:
+        mntpoint = loopback_root + '/' + devname.rsplit('/')[-1]
+        _logger.debug('Loopback mountpoint: %s' % mntpoint)
+        try:
+            if exec_mkdir(mntpoint):
+                _logger.debug('Mountpoint: %s created.' % mntpoint)
+        except Exception as e:
+            _logger.critical('Failed to create mountpoint %s: %s'
+                            % (mntpoint, str(e)))
+            raise OciMigrateException('Failed to create mountpoint %s: %s'
+                                      % (mntpoint, str(e)))
+    else:
+        mntpoint = mountpoint
+    #
+    # actual mount
+    cmd = ['mount', devname, mntpoint]
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('%s mounted on %s: %s' % (devname, mntpoint, str(output)))
+        return mntpoint
+    except Exception as e:
+        #
+        # mount failed, need to remove mountpoint.
+        _logger.critical('failed to mount %s: %s' % (devname, str(e)))
+        if mountpoint is None:
+            if exec_rmdir(mntpoint):
+                _logger.debug('%s removed' % mntpoint)
+            else:
+                _logger.critical('Failed to remove mountpoint %s' % mntpoint)
+    return None
+
+
+def find_os_specific(ostag):
+    """
+    Look for the os type specific code.
+
+    Parameters
+    ----------
+    ostag: str
+        The os type id.
+
+    Returns
+    -------
+        str: The module name on success, None otherwise.
+    """
+    module = None
+    package_name = module_home
+    pkg = __import__(package_name)
+    path = os.path.dirname(sys.modules.get(package_name).__file__)
+    thismodule = os.path.splitext(
+        os.path.basename(sys.modules[__name__].__file__))[0]
+    _logger.debug('Path: %s' % path)
+    _logger.debug('ostag: %s' % ostag)
+    _logger.debug('This module: %s' % sys.modules[__name__].__file__)
+    try:
+        for _, module_name, _ in pkgutil.iter_modules([path]):
+            #
+            # find os_type_tag in files, contains a comma separted list of
+            # supported os id's
+            _logger.debug('module_name: %s' % module_name)
+            if module_name != thismodule:
+                modulefile = path + '/' + module_name + '.py'
+                if os.path.isfile(modulefile):
+                    with open(modulefile, 'rb') as f:
+                        for fline in f:
+                            if '_os_type_tag_csl_tag_type_os_' in fline.strip():
+                                _logger.debug('Found os_type_tag in %s.'
+                                              % module_name)
+                                _logger.debug('In line:\n  %s' % fline)
+                                if ostag in \
+                                        re.sub("[ ']", "", fline).split('=')[1].split(','):
+                                    _logger.debug('Found ostag in %s.' % module_name)
+                                    module = module_name
+                                else:
+                                    _logger.debug('ostag not found in %s.' % module_name)
+                                break
+                else:
+                    _logger.debug('No file found for module %s' % module_name)
+    except Exception as e:
+        _logger.critical('Failed to locate the OS type specific module: %s'
+                        % str(e))
+    return module
+
+
+def mount_pseudo(rootdir):
+    """
+    Remount proc, sys and dev.
+
+    Parameters
+    ----------
+    rootdir: str
+        The mountpoint of the root partition.
+
+    Returns
+    -------
+        list: The list of new mountpoints on success, None otherwise.
+    """
+    pseudodict = {'proc' : ['-t', 'proc', 'none', '%s/proc' % rootdir],
+                  'dev'  : ['-o', 'bind', '/dev', '%s/dev' % rootdir],
+                  'sys'  : ['-o', 'bind', '/sys', '%s/sys' % rootdir]}
+
+    pseudomounts = []
+    _logger.debug('Mounting: %s' % pseudodict)
+    for dirs, cmd_par in six.iteritems(pseudodict):
+        cmd = ['mount'] + cmd_par
+        _logger.debug('Mounting %s' % dirs)
+        pause_msg(cmd)
+        try:
+            _logger.debug('Command: %s' % cmd)
+            output = migrate_tools.run_popen_cmd(cmd)
+            _logger.debug('%s : %s' % (cmd, str(output)))
+            pseudomounts.append(cmd_par[3])
+        except Exception as e:
+            _logger.critical('Failed to %s: %s' % (cmd, str(e)))
+            raise OciMigrateException('Failed to %s: %s' % (cmd, str(e)))
+    return pseudomounts
+
+
+def mount_fs(mountpoint):
+    """
+    Mount a filesystem specified in fstab, by mountpoint only.
+
+    Parameters
+    ----------
+    mountpoint: str
+        The mountpoint.
+
+    Returns
+    -------
+        bool: True on success, False otherwise
+    """
+    cmd = ['mount', mountpoint]
+    pause_msg(cmd)
+    _logger.debug('Mounting %s' % mountpoint)
+    try:
+        _logger.debug('Command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('%s success: %s' % (cmd, str(output)))
+        return True
+    except Exception as e:
+        _logger.error('Failed to %s: %s' % (cmd, str(e)))
+        return False
+
+
+@state_loop(3)
+def unmount_something(mountpoint):
+    """
+    Unmount.
+
+    Parameters
+    ----------
+    mountpoint: str
+        The mountpoint.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    if os.path.ismount(mountpoint):
+        _logger.debug('%s is a mountpoint.' % mountpoint)
+    else:
+        _logger.debug('%s is not a mountpoint, quitting' % mountpoint)
+        return True
+    #
+    cmd = ['umount', mountpoint]
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('%s : %s' % (cmd, str(output)))
+    except Exception as e:
+        _logger.error('Failed to %s: %s' % (cmd, str(e)))
+        return False
+    return True
+
+
+def unmount_pseudo(pseudomounts):
+    """
+    Unmount the pseudodevices.
+
+    Parameters
+    ----------
+    pseudomounts: list
+        The list of pseudodevices
+
+    Returns
+    -------
+        True on success, False otherwise.
+    """
+    _logger.debug('Unmounting %s' % pseudomounts)
+    res = True
+    for mnt in pseudomounts:
+        _logger.debug('Unmount %s' % mnt)
+        umount_res = unmount_something(mnt)
+        if umount_res:
+            _logger.debug('%s successfully unmounted.' % mnt)
+        else:
+            _logger.error('Failed to unmount %s' % mnt)
+            res = False
+    return res
+
+
+def exec_pvscan(devname=None):
+    """
+    Update the lvm cache.
+
+    Returns
+    -------
+        bool: True on success, raises an exeception on failure.
+    """
+    if devname is not None:
+        cmd = ['pvscan', '--cache', devname]
+    else:
+        cmd = ['pvscan', '--cache']
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('Physical volumes scanned on %s: %s'
+                     % (devname, str(output)))
+        return True
+    except Exception as e:
+        #
+        # pvscan failed
+        _logger.critical('Failed to scan %s for physical '
+                        'volumes: %s' % (devname, str(e)))
+        raise OciMigrateException('Failed to scan %s for physical '
+                                  'volumes: %s' % (devname, str(e)))
+
+
+def exec_vgscan():
+    """
+    Scan the system for (new) volume groups.
+
+    Returns
+    -------
+        bool: True on success, raises an exeception on failure.
+    """
+    cmd = ['vgscan', '--verbose']
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('Volume groups scanned: %s' % str(output))
+        return True
+    except Exception as e:
+        #
+        # vgscan failed
+        _logger.critical('Failed to scan for volume groups: %s' % str(e))
+        raise OciMigrateException('Failed to scan for volume groups: %s'
+                                  % str(e))
+
+
+def exec_lvscan():
+    """
+    Scan the system for (new) logical volumes.
+
+    Returns
+    -------
+        dict:  inactive, supposed new, volume groups with list of logical
+        volumes on success, raises an exeception on failure.
+    """
+    cmd = ['lvscan', '--verbose']
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('Logical volumes scanned: %s' % str(output))
+        new_vgs = dict()
+        for lvdevdesc in output.splitlines():
+            if 'inactive' in lvdevdesc:
+                lvarr = re.sub(r"'", "", lvdevdesc).split()
+                lvdev = lvarr[1]
+                vgarr = re.sub(r"/", " ", lvdev).split()
+                vgdev = vgarr[1]
+                lvdev = vgarr[2]
+                # mapperdev = re.sub(r"-", "--", vgdev) + '-' + vgarr[2]
+                mapperdev = re.sub(r"-", "--", vgdev) \
+                            + '-' \
+                            + re.sub(r"-", "--", lvdev)
+                _logger.debug('vg %s lv %s mapper %s'
+                             % (vgdev, lvdev, mapperdev))
+                if vgdev not in new_vgs.keys():
+                    new_vgs[vgdev] = [(lvdev, mapperdev)]
+                else:
+                    new_vgs[vgdev].append((lvdev, mapperdev))
+                _logger.debug('vg: %s  lv: %s' % (vgdev, lvdev))
+        _logger.debug('New logical volumes: %s' % new_vgs)
+        return new_vgs
+    except Exception as e:
+        #
+        # vgscan failed
+        _logger.critical('Failed to scan for logical volumes: %s' % str(e))
+        raise OciMigrateException('Failed to scan for logical volume: %s'
+                                  % str(e))
+
+
+def exec_vgchange(changecmd):
+    """
+    Execute vgchange command.
+
+    Parameters
+    ----------
+    changecmd: list
+        Parameters for the vgchange command.
+
+    Returns
+    -------
+
+    """
+    cmd = ['vgchange'] + changecmd
+    _logger.debug('vgchange command: %s' % cmd)
+    pause_msg(cmd)
+    try:
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('vgchange result: %s' % output)
+        return output
+    except Exception as e:
+        _logger.critical('Failed to execute %s: %s' % (cmd, str(e)))
+        raise OciMigrateException('Failed to execute %s: %s' % (cmd, str(e)))
+
+
+@state_loop(2)
+def mount_lvm2(devname):
+    """
+    Create the mountpoints /mnt/<last part of lvm partitions> and mount the
+    partitions on those mountpoints, if possible.
+
+    Parameters
+    ----------
+    devname: str
+        The full path of the device
+
+    Returns
+    -------
+        list: The list of mounted partitions.
+        ?? need to collect lvm2 list this way??
+    """
+    _logger.debug('Device %s contains an lvm2' % devname)
+
+    try:
+        #
+        # physical volumes
+        if exec_pvscan(devname):
+            _logger.debug('pvscan %s succeeded' % devname)
+        else:
+            _logger.critical('pvscan %s failed' % devname)
+        #
+        pause_msg('pvscan test')
+        #
+        # volume groups
+        if exec_vgscan():
+            _logger.debug('vgscan succeeded')
+        else:
+            _logger.critical('vgscan failed')
+        #
+        pause_msg('vgscan test')
+        #
+        # logical volumes
+        vgs = exec_lvscan()
+        if vgs is not None:
+            _logger.debug('lvscan succeeded: %s' % vgs)
+        else:
+            _logger.critical('lvscan failed')
+        #
+        pause_msg('lvscan test')
+        #
+        # make available
+        vgchangeargs = ['--activate', 'y']
+        vgchangeres = exec_vgchange(vgchangeargs)
+        _logger.debug('vgchange: %s' % vgchangeres)
+        #
+        pause_msg('vgchangeres test')
+        vgfound = False
+        if vgchangeres is not None:
+            for resline in vgchangeres.splitlines():
+                _logger.debug('vgchange line: %s' % resline)
+                for vg in vgs.keys():
+                    if vg in resline:
+                        _logger.debug('vgfound set to True')
+                        vgfound = True
+                    else:
+                        _logger.debug('vg %s not in l' % vg)
+            _logger.debug('vgchange: %s, %s' % (vgchangeres, vgfound))
+            #
+            # for the sake of testing
+            pause_msg('vgchangeres test')
+        else:
+            _logger.critical('vgchange failed')
+        return vgs
+    except Exception as e:
+        _logger.critical('Mount lvm %s failed: %s' % (devname, str(e)))
+        raise OciMigrateException('Mount lvm %s failed: %s' % (devname, str(e)))
+
+
+def get_oci_config(section='DEFAULT'):
+    """
+    Read the oci configuration file.
+
+    Parameters
+    ----------
+    section: str
+        The section from the oci configuration file. DEFAULT is the default.
+        (todo: add command line option to use other user/sections)
+
+    Returns
+    -------
+        dict: the contents of the configuration file as a dictionary.
+    """
+    _logger.debug('Reading the %s configuration file.' %
+                 get_config_data('ociconfigfile'))
+    thisparser = ConfigParser()
+    try:
+        rf = thisparser.read(get_config_data('ociconfigfile'))
+        sectiondata = dict(thisparser.items(section))
+        _logger.debug('OCI configuration: %s' % sectiondata)
+        return sectiondata
+    except Exception as e:
+        _logger.error('Failed to read OCI configuration %s: %s.' %
+                     (get_config_data('ociconfigfile'), str(e)))
+        raise OciMigrateException('Failed to read OCI configuration %s: %s.' %
+                                  (get_config_data('ociconfigfile'),
+                                   str(e)))
+
+
+def bucket_exists(bucketname):
+    """
+    Verify if bucketname exits.
+
+    Parameters
+    ----------
+    bucketname: str
+        The bucketname.
+
+    Returns
+    -------
+        object: The bucket on success, raise an exception otherwise
+    """
+    _logger.debug('Test bucket %s.' % bucketname)
+    thispath = os.getenv('PATH')
+    _logger.debug('PATH is %s' % thispath)
+    cmd = ['which', 'oci']
+    try:
+        ocipath = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('oci path is %s' % ocipath)
+    except Exception as e:
+        _logger.error('Cannot find oci anymore: %s' % str(e))
+
+    cmd = ['oci', 'os', 'object', 'list', '--bucket-name', bucketname]
+    pause_msg(cmd)
+    try:
+        bucketresult = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('Result: \n%s' % bucketresult)
+        return bucketresult
+    except Exception as e:
+        _logger.debug('Bucket %s does not exists or the authorisation is '
+                        'missing: %s.' % (bucketname, str(e)))
+        raise OciMigrateException('Bucket %s does not exists or the '
+                                  'authorisation is missing: %s.'
+                                  % (bucketname, str(e)))
+
+
+def object_exists(bucket, object_name):
+    """
+    Verify if the object object_name already exists in the
+    object storage.
+
+    Parameters
+    ----------
+    bucket: object
+        The bucket.
+    object_name: str
+        The object name.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    _logger.debug('Testing if %s already exists.' % object_name)
+    testresult_json = json.loads(bucket)
+    _logger.debug('Result: \n%s', testresult_json)
+    if 'data' in testresult_json:
+        for res in testresult_json['data']:
+            if str(res['name']) == object_name:
+                _logger.debug('%s found' % object_name)
+                return True
+            else:
+                _logger.debug('%s not found' % object_name)
+    else:
+        _logger.debug('Bucket %s is empty.' % bucket)
+    return False
+
+
+def set_default_user(cfgfile, username):
+    """
+    Update the default user name in the cloud.cfg file.
+    Paramaters:
+    ----------
+        cfgfile: str
+            full path of the cloud init config file, yaml format.
+        username: str
+            name of the default cloud user.
+
+    Returns:
+    -------
+        bool: True on success, False otherwise.
+    """
+    _logger.debug('Updating cloud.cfg file %s, setting default username to '
+                  '%s.' % (cfgfile, username))
+    if migrate_tools.file_exists(cfgfile):
+        _logger.debug('Copy %s %s' % (cfgfile, os.path.split(cfgfile)[0]
+                                      + '/bck_'
+                                      + os.path.split(cfgfile)[1]
+                                      + '_'
+                                      + migrate_tools.thistime))
+        shutil.copy(cfgfile, os.path.split(cfgfile)[0]
+                    + '/bck_'
+                    + os.path.split(cfgfile)[1]
+                    + '_'
+                    + migrate_tools.thistime)
+        with open(cfgfile, 'r') as f:
+            cloudcfg = yaml.load(f, Loader=yaml.SafeLoader)
+        if type(cloudcfg) is dict:
+            if 'system_info' in cloudcfg.keys() \
+                    and 'default_user' in cloudcfg['system_info'].keys() \
+                    and 'name' in cloudcfg['system_info']['default_user'].keys():
+                cloudcfg['system_info']['default_user']['name'] = username
+                with open(cfgfile, 'w') as f:
+                    yaml.dump(cloudcfg, f, width=50)
+                _logger.debug('Cloud configuration file %s successfully updated.' % cfgfile)
+                return True
+            else:
+                _logger.debug('No default username found in cloud config file.')
+        else:
+            _logger.error('Invalid cloud config file.')
+    else:
+        _logger.error('Cloud config file %s does not exist.' % cfgfile)
+    return False
+
+
+def upload_image(imgname, bucketname, ociname):
+    """
+    Upload the validated and updated image imgname to the OCI object storage
+    bucketname as ociname.
+
+    Parameters
+    ----------
+    imgname: str
+        The on-premise custom image.
+    bucketname: str
+        The OCI object storage name.
+    ociname:
+        The OCI image name.
+
+    Returns
+    -------
+        bool: True on success, raises an exception otherwise.
+    """
+    _logger.debug('Uploading %s to %s as %s.' % (imgname, bucketname, ociname))
+    cmd = ['oci', 'os', 'object', 'put', '--bucket-name',
+           bucketname, '--file', imgname, '--name', ociname]
+    pause_msg(cmd)
+    try:
+        uploadresult = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('Successfully uploaded %s to %s as %s: %s.'
+                     % (imgname, bucketname, ociname, uploadresult))
+    except Exception as e:
+        _logger.critical('Failed to upload %s to object storage %s as %s: %s.'
+                        % (imgname, bucketname, ociname, str(e)))
+        raise OciMigrateException('Failed to upload %s to object storage %s '
+                                  'as %s: %s.'
+                                  % (imgname, bucketname, ociname, str(e)))
+
+
+def unmount_lvm2(vg):
+    """
+    Remove logical volume data from system.
+
+    Parameters
+    ----------
+    vg: dict
+        Volume group with list of logical volumes.
+
+    Returns
+    -------
+        bool: True on Success, exception otherwise.
+    """
+    try:
+        #
+        # make unavailable
+        for vg_name in vg.keys():
+            vgchangeres = exec_vgchange(['--activate', 'n', vg_name])
+            _logger.debug('vgchange: %s' % vgchangeres)
+        #
+        # remove physical volume: clear cache, if necessary
+        if exec_pvscan():
+            _logger.debug('pvscan clear succeeded')
+        else:
+            _logger.error('pvscan failed')
+    except Exception as e:
+        _logger.error('Failed to release lvms %s: %s' % vg, str(e))
+        migrate_tools.error_msg('Failed to release lvms %s: %s' % vg, str(e))
+        # raise OciMigrateException('Exception raised during release
+        # lvms %s: %s' % (vg, str(e)))
+
+
+@state_loop(5, 2)
+def unmount_part(devname):
+    """
+    Unmount a partition from mountpoint from /mnt/<last part of device
+    specification> and remove the mountpoint.
+
+    Parameters
+    ----------
+    devname: str
+        The full path of the device.
+
+    Returns
+    -------
+        bool
+            True on success, False otherwise.
+    """
+    mntpoint = loopback_root + '/' + devname.rsplit('/')[-1]
+    cmd = ['umount', mntpoint]
+    pause_msg(cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        if run_call_cmd(cmd) == 0:
+            _logger.debug('%s unmounted from %s' % (devname, mntpoint))
+            #
+            # remove mountpoint
+            if exec_rmdir(mntpoint):
+                _logger.debug('%s removed' % mntpoint)
+                return True
+            else:
+                _logger.critical('Failed to remove mountpoint %s' % mntpoint)
+                raise OciMigrateException('Failed to remove mountpoint %s'
+                                          % mntpoint)
+        else:
+            _logger.critical('Failed to unmount %s' % devname)
+    except Exception as e:
+        _logger.critical('Failed to unmount %s: %s' % (devname, str(e)))
+    return False
+
+
+def print_header(head):
+    """
+    Display header for image data component.
+
+    Parameters
+    ----------
+    head: str
+        The header
+
+    Returns
+    -------
+        No return value.
+    """
+    migrate_tools.result_msg(msg='\n  %30s\n  %30s' % (head, '-'*30), result=True)
+
+
+def show_image_data(imgobj):
+    """
+    Show the collected data about the image.
+
+    Parameters
+    ----------
+    imgobj: object
+        The data about the image.
+
+    Returns
+    -------
+        No return value.
+    """
+    print_header('Components collected.')
+    for k, v in sorted(six.iteritems(imgobj._img_info)):
+        migrate_tools.result_msg(msg='  %30s' % k, result=True)
+
+    _logger.debug('show data')
+    print('\n  %25s\n  %s' % ('Image data:', '-'*60))
+    #
+    # name
+    fnname = '  missing'
+    print_header('Image file path.')
+    if 'img_name' in imgobj._img_info:
+        fnname = imgobj._img_info['img_name']
+    migrate_tools.result_msg(msg='  %30s' % fnname, result=True)
+    #
+    # type
+    imgtype = '  missing'
+    print_header('Image type.')
+    if 'img_type' in imgobj._img_info:
+        imgtype = imgobj._img_info['img_type']
+    migrate_tools.result_msg(msg='  %30s' % imgtype, result=True)
+    #
+    # size
+    imgsizes = '    physical: missing data\n    logical:  missing data'
+    print_header('Image size:')
+    if 'img_size' in imgobj._img_info:
+        imgsizes = '    physical: %8.2f GB\n      logical:  %8.2f GB' \
+                   % (imgobj._img_info['img_size']['physical'],
+                      imgobj._img_info['img_size']['logical'])
+    migrate_tools.result_msg(msg='%s' % imgsizes, result=True)
+    #
+    # header
+    if 'img_header' in imgobj._img_info:
+        try:
+            imgobj.show_header()
+        except Exception as e:
+            migrate_tools.result_msg(msg='Failed to show the image hadear: %s'
+                                     % str(e), result=True)
+    else:
+        migrate_tools.result_msg(msg='\n  Image header data missing.', result=True)
+    #
+    # mbr
+    mbr = '  missing'
+    print_header('Master Boot Record.')
+    if 'mbr' in imgobj._img_info:
+        if 'hex' in imgobj._img_info['mbr']:
+            mbr = imgobj._img_info['mbr']['hex']
+        migrate_tools.result_msg(msg='%s' % mbr, result=True)
+    #
+    # partition table
+        print_header('Partiton Table.')
+        parttabmissing = '  Partition table data is missing.'
+        if 'partition_table' in imgobj._img_info['mbr']:
+            show_partition_table(imgobj._img_info['mbr']['partition_table'])
+        else:
+            migrate_tools.result_msg(msg=parttabmissing, result=True)
+    #
+    # parted data
+    print_header('Parted data.')
+    parteddata = '  Parted data is missing.'
+    if 'parted' in imgobj._img_info:
+        show_parted_data(imgobj._img_info['parted'])
+    else:
+        migrate_tools.result_msg(msg='%s' % parteddata, result=True)
+    #
+    # partition data
+    print_header('Partition Data.')
+    partdata = '  Partition data is missing.'
+    if 'partitions' in imgobj._img_info:
+        show_partition_data(imgobj._img_info['partitions'])
+    else:
+        migrate_tools.result_msg(msg='%s' % partdata, result=True)
+    #
+    # grub config data
+    print_header('Grub configuration data.')
+    grubdat = '  Grub configuration data is missing.'
+    if 'grubdata' in imgobj._img_info:
+        show_grub_data(imgobj._img_info['grubdata'])
+    else:
+        migrate_tools.result_msg(msg='%s' % grubdat, result=True)
+    #
+    # logical volume data
+    print_header('Logical Volume data.')
+    lvmdata = '  Logical Volume data is missing.'
+    if 'volume_groups' in imgobj._img_info:
+        if imgobj._img_info['volume_groups']:
+            show_lvm2_data(imgobj._img_info['volume_groups'])
+    else:
+        migrate_tools.result_msg(msg=lvmdata, result=True)
+    #
+    # various data:
+    print_header('Various data.')
+    if 'bootmnt' in imgobj._img_info:
+        migrate_tools.result_msg(msg='  %30s: %s mounted on %s'
+                                 % ('boot', imgobj._img_info['bootmnt'][0],
+                                    imgobj._img_info['bootmnt'][1]),
+                             result=True)
+    if 'rootmnt' in imgobj._img_info:
+        migrate_tools.result_msg(msg='  %30s: %s mounted on %s'
+                                 % ('root', imgobj._img_info['rootmnt'][0],
+                                    imgobj._img_info['rootmnt'][1]),
+                             result=True)
+    if 'boot_type' in imgobj._img_info:
+        migrate_tools.result_msg(msg='  %30s: %-30s'
+                                 % ('boot type:', imgobj._img_info['boot_type']),
+                             result=True)
+    #
+    # fstab
+    print_header('fstab data.')
+    fstabmiss = '  fstab data is missing.'
+    if 'fstab' in imgobj._img_info:
+        show_fstab(imgobj._img_info['fstab'])
+    else:
+        migrate_tools.result_msg(msg=fstabmiss, result=True)
+    #
+    # network
+    # print_header('Network configuration data.')
+    # networkmissing = '  Network configuration data is missing.'
+    # if 'network' in imgobj._img_info:
+    #     show_network_data(imgobj._img_info['network'])
+    # else:
+    #     migrate_tools.result_msg(msg=networkmissing, result=True)
+    #
+    # os release data
+    print_header('Operating System information.')
+    osinfomissing = '  Operation System information is missing.'
+    if 'osinformation' in imgobj._img_info:
+        for k in sorted(imgobj._img_info['osinformation']):
+            migrate_tools.result_msg(msg='  %30s : %-30s'
+                                     % (k, imgobj._img_info['osinformation'][k]),
+                                 result=True)
+    else:
+        migrate_tools.result_msg(msg=osinfomissing, result=True)
+    #
+    # oci configuration
+    print_header('OCI client configuration.')
+    ociconfmissing = '  OCI client configuration not found.'
+    if 'oci_config' in imgobj._img_info:
+        for k in sorted(imgobj._img_info['oci_config']):
+            migrate_tools.result_msg(msg='  %30s : %-30s'
+                                     % (k, imgobj._img_info['oci_config'][k]),
+                                 result=True)
+    else:
+        migrate_tools.result_msg(msg=ociconfmissing, result=True)
+
+
+def show_partition_table(table):
+    """
+    Show the relevant data of the partition table.
+
+    Parameters
+    ----------
+    table: list of dict.
+        The partition table data.
+
+    Returns
+    -------
+        No return value.
+    """
+    migrate_tools.result_msg(msg='  %2s %5s %16s %32s'
+                             % ('nb', 'boot', 'type', 'data'), result=True)
+    migrate_tools.result_msg(msg='  %2s %5s %16s %32s'
+                             % ('-'*2, '-'*5, '-'*16, '-'*32), result=True)
+    for i in range(0, 4):
+        if table[i]['boot']:
+            bootflag = 'YES'
+        else:
+            bootflag = ' NO'
+        migrate_tools.result_msg(msg='  %02d %5s %16s %32s'
+                                 % (i, bootflag,
+                                    table[i]['type'],
+                                    table[i]['entry']),
+                             result=True)
+
+
+def show_img_header(headerdata):
+    """
+    Show the header data.
+
+    Parameters
+    ----------
+    headerdata: dict
+        Dictionary containing data extracted from the image header; contents
+        is dependent form image type.
+
+    Returns
+    -------
+        No return value.
+    """
+    migrate_tools.result_msg(msg='\n  %30s\n  %30s'
+                             % ('Image header:', '-'*30), result=True)
+    for k, v in sorted(headerdata):
+        migrate_tools.result_msg(msg='  %30s : %s' % (k, v), result=True)
+
+
+def show_fstab(fstabdata):
+    """
+    Show the relevant data in the fstab file.
+
+    Parameters
+    ----------
+    fstabdata: list of lists, one list per fstab line.
+
+    Returns
+    -------
+        No return value.
+    """
+    for line in fstabdata:
+        migrate_tools.result_msg(
+            msg='%60s %20s %8s %20s %2s %2s'
+                % (line[0], line[1], line[2], line[3], line[4], line[5]),
+            result=True)
+
+
+def show_grub_data(grublist):
+    """
+    Show the relevant data in the grub config file.
+
+    Parameters
+    ----------
+    grublist: list of dictionaries, 1 per boot section, containing grub
+    lines as list.
+
+    Returns
+    -------
+        No return value.
+    """
+    for entry in grublist:
+        _logger.debug('%s' % entry)
+        for grubkey in entry:
+            # print entry[grubkey]
+            for grubline in entry[grubkey]:
+                migrate_tools.result_msg(msg=grubline, result=True)
+            migrate_tools.result_msg(msg='\n', result=True)
+
+
+def show_parted_data(parted_dict):
+    """
+    Show the data collected by the parted command.
+
+    Parameters
+    ----------
+    parted_dict: dict
+        The data.
+
+    Returns
+    -------
+        No return value.
+    """
+    for k, v in sorted(six.iteritems(parted_dict)):
+        migrate_tools.result_msg(msg='%30s : %s' % (k, v), result=True)
+    migrate_tools.result_msg(msg='\n', result=True)
+
+
+def show_lvm2_data(lvm2_data):
+    """
+    Show the collected lvm2 data.
+
+    Parameters
+    ----------
+    lvm2_data: dict
+        Dictionary containing the recognised volume groups and logical volumes.
+
+    Returns
+    -------
+        No return value.
+    """
+    for k, v in sorted(six.iteritems(lvm2_data)):
+        migrate_tools.result_msg(msg='\n  Volume Group: %s:' % k, result=True)
+        for t in v:
+            migrate_tools.result_msg(msg='%40s : %-30s' % (t[0], t[1]), result=True)
+    migrate_tools.result_msg(msg='\n', result=True)
+
+
+def show_partition_data(partition_dict):
+    """
+    Show the collected data on the partitions of the image file.
+
+    Parameters
+    ----------
+    partition_dict: dict
+        The data.
+
+    Returns
+    -------
+        No return value
+    """
+    for k, v in sorted(six.iteritems(partition_dict)):
+        migrate_tools.result_msg(msg='%30s :\n%s'
+                                 % ('partition %s' % k, '-'*60), result=True)
+        for x, y in sorted(six.iteritems(v)):
+            migrate_tools.result_msg(msg='%30s : %s' % (x, y), result=True)
+        migrate_tools.result_msg(msg='\n', result=True)
+    migrate_tools.result_msg(msg='\n', result=True)
+
+
+def show_network_data(networkdata):
+    """
+    Show the collected data on the network interfaces.
+
+    Parameters
+    ----------
+    networkdata: dict
+        Dictionary of dictionaries containing the network configuration data.
+
+    Returns
+    -------
+        No return value.
+    """
+    for nic, nicdata in sorted(six.iteritems(networkdata)):
+        migrate_tools.result_msg(msg='  %20s:' % nic, result=True)
+        for k, v in sorted(six.iteritems(nicdata)):
+            migrate_tools.result_msg(msg='  %30s = %s' % (k, v), result=True)
+
+
+def show_hex_dump(bindata):
+    """
+    Show hex and readable version of binary data.
+
+    Parameters
+    ----------
+    bindata: binary data.
+
+    Returns
+    -------
+        str: hexdump format
+    """
+    blocklen = 16
+    ll = len(bindata)
+    m = bindata
+    hexdata = ''
+    addr = 0
+    try:
+        while ll > 0:
+            x = m[0:blocklen]
+            line = ' '.join(['%02x' % i for i in bytearray(x)])
+            line = line[0:23] + ' ' + line[23:]
+            readable = ''.join([chr(i) if 32 <= i <= 127
+                                else '.' for i in bytearray(x)])
+            hexdata += '%08x : %s : %s :\n' % (addr*16, line, readable)
+            y = m[blocklen:]
+            m = y
+            addr += 1
+            ll -= blocklen
+    except Exception as e:
+        _logger.error('exception: %s' % str(e))
+    return hexdata

--- a/lib/oci_utils/migrate/migrate_utils.py
+++ b/lib/oci_utils/migrate/migrate_utils.py
@@ -289,7 +289,6 @@ def exec_rmdir(dirname):
            True on success, raises an exception otherwise.
     """
     _logger.debug('Removing directory tree.')
-    cmd = ['rmdir']
     try:
         shutil.rmtree(dirname)
         return True

--- a/lib/oci_utils/migrate/ol_type_os.py
+++ b/lib/oci_utils/migrate/ol_type_os.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 
@@ -44,7 +44,7 @@ def exec_yum(cmd):
     _logger.debug('yum command: %s' % cmd)
     try:
         _logger.debug('command: %s' % cmd)
-        output = migrate_tools.run_popen_cmd(cmd)
+        output = migrate_tools.run_popen_cmd(cmd).decode('utf-8')
         _logger.debug('yum command output: %s' % str(output))
         return output
     except Exception as e:
@@ -77,9 +77,9 @@ def install_cloud_init(*args):
         # verify if latest channel is enabled.
         rpmlist = exec_yum(['list', 'cloud-init'])
         cloud_init_present = False
-        for l in rpmlist.splitlines():
-            _logger.debug('%s' % l)
-            if 'cloud-init' in l:
+        for ll in rpmlist.splitlines():
+            _logger.debug('%s' % ll)
+            if 'cloud-init' in ll:
                 _logger.debug('The rpm cloud-init is available.')
                 cloud_init_present = True
                 break
@@ -92,7 +92,7 @@ def install_cloud_init(*args):
         else:
             installoutput = exec_yum(['install', '-y', 'cloud-init'])
             _logger.debug('Successfully installed cloud init:\n%s'
-                         % installoutput)
+                          % installoutput)
         pause_msg('Installed cloud-init here, or not.')
         if migrate_tools.restore_nameserver():
             _logger.debug('Restoring nameserver info succeeded.')

--- a/lib/oci_utils/migrate/ol_type_os.py
+++ b/lib/oci_utils/migrate/ol_type_os.py
@@ -1,0 +1,107 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+""" Module containing Oracle Linux type specific OS methods.
+"""
+import logging
+
+from oci_utils.migrate import console_msg, pause_msg
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.exception import OciMigrateException
+
+_logger = logging.getLogger('oci-utils.ol-type-os')
+
+_os_type_tag_csl_tag_type_os_ = 'ol, rhel, fedora, centos,'
+
+
+def os_banner():
+    """
+    Show OS banner.
+    Returns
+    -------
+        No return value.
+    """
+    console_msg('OS is one of %s' % _os_type_tag_csl_tag_type_os_)
+
+
+def exec_yum(cmd):
+    """
+    Execute a yum command.
+
+    Parameters
+    ----------
+    cmd: list
+        The yum command parameters as s list.
+
+    Returns
+    -------
+        str: yum output on success, raises an exception otherwise.
+    """
+    cmd = ['yum'] + cmd
+    _logger.debug('yum command: %s' % cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('yum command output: %s' % str(output))
+        return output
+    except Exception as e:
+        _logger.critical('Failed to execute yum: %s' % str(e))
+        raise OciMigrateException('\nFailed to execute yum: %s' % str(e))
+
+
+def install_cloud_init(*args):
+    """
+    Install the cloud-init package.
+
+    Parameters
+    ----------
+    args: tuple
+        1 argument expected, the VERSION_ID as a string and as specified in the
+        os-release file.
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    try:
+        #
+        # set current nameserver config.
+        if migrate_tools.set_nameserver():
+            _logger.debug('Updating nameserver info succeeded.')
+        else:
+            _logger.error('Failed to update nameserver info.')
+        #
+        # verify if latest channel is enabled.
+        rpmlist = exec_yum(['list', 'cloud-init'])
+        cloud_init_present = False
+        for l in rpmlist.splitlines():
+            _logger.debug('%s' % l)
+            if 'cloud-init' in l:
+                _logger.debug('The rpm cloud-init is available.')
+                cloud_init_present = True
+                break
+        if not cloud_init_present:
+            _logger.error('The rpm cloud-init is missing.')
+            migrate_tools.migrate_preparation = False
+            migrate_tools.migrate_non_upload_reason += \
+                '\n  The rpm package cloud-initis missing from the yum repository.'
+            return False
+        else:
+            installoutput = exec_yum(['install', '-y', 'cloud-init'])
+            _logger.debug('Successfully installed cloud init:\n%s'
+                         % installoutput)
+        pause_msg('Installed cloud-init here, or not.')
+        if migrate_tools.restore_nameserver():
+            _logger.debug('Restoring nameserver info succeeded.')
+        else:
+            _logger.error('Failed to restore nameserver info.')
+    except Exception as e:
+        _logger.critical('Failed to install cloud init package:\n%s' % str(e))
+        migrate_tools.error_msg('Failed to install cloud init package:\n%s' % str(e))
+        migrate_tools.migrate_non_upload_reason += \
+            '\n Failed to install cloud init package: %s' % str(e)
+        return False
+    return True

--- a/lib/oci_utils/migrate/qcow2.py
+++ b/lib/oci_utils/migrate/qcow2.py
@@ -1,0 +1,230 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module to handle QCOW2 formatted virtual disk images.
+"""
+import logging
+import os
+import struct
+
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.imgdevice import DeviceData
+from oci_utils.migrate.migrate_utils import gigabyte as gigabyte
+from oci_utils.migrate.migrate_utils import OciMigrateException
+
+"""
+  typedef struct QCowHeader {
+      uint32_t magic;
+      uint32_t version;
+      uint64_t backing_file_offset;
+      uint32_t backing_file_size;
+      uint32_t cluster_bits;
+      uint64_t size; /* in bytes */
+      uint32_t crypt_method;
+      uint32_t l1_size;
+      uint64_t l1_table_offset;
+      uint64_t refcount_table_offset;
+      uint32_t refcount_table_clusters;
+      uint32_t nb_snapshots;
+      uint64_t snapshots_offset;
+  } QCowHeader;
+"""
+
+format_data = {'514649fb': {'name': 'qcow2',
+                            'module': 'qcow2',
+                            'clazz': 'Qcow2Head',
+                            'prereq': {'MAX_IMG_SIZE_GB': 300.0}}}
+
+_logger = logging.getLogger('oci-utils.qcow2')
+
+
+class Qcow2Head(DeviceData):
+    """
+    Class to analyse header of qcow2 image file
+
+    Attributes
+    ----------
+        stat: tuple
+            The image file stat data.
+        img_tag: str
+            The bare file name.
+        qcowhead_dict: dict
+            The qcow2 file header as a dictionary.
+    """
+    # qcow2 header definition:
+    uint32_t = 'I'  # 32bit unsigned int
+    uint64_t = 'Q'  # 64bit unsigned long
+    header2_structure = [[uint32_t, '%#x', 'magic'],
+                         [uint32_t, '%d',  'version'],
+                         [uint64_t, '%#x', 'backing_file_offset'],
+                         [uint32_t, '%#x', 'backing_file_size'],
+                         [uint32_t, '%d',  'cluster_bits'],
+                         [uint64_t, '%d',  'size'],
+                         [uint32_t, '%d',  'crypt_method'],
+                         [uint32_t, '%d',  'l1_size'],
+                         [uint64_t, '%#x', 'l1_table_offset'],
+                         [uint64_t, '%d',  'refcount_table_offset'],
+                         [uint32_t, '%d',  'refcount_table_clusters'],
+                         [uint32_t, '%d',  'nb_snapshots'],
+                         [uint64_t, '%#x', 'snapshots_offset'],
+                         [uint64_t, '%#x', 'incompatible_features'],
+                         [uint64_t, '%#x', 'compatible_features'],
+                         [uint64_t, '%#x', 'autoclear_features'],
+                         [uint32_t, '%d',  'refcount_order'],
+                         [uint32_t, '%d',  'header_length']]
+
+    # struct format string
+    qcowhead_fmt = '>' + ''.join(f[0] for f in header2_structure)
+    head_size = struct.calcsize(qcowhead_fmt)
+
+    def __init__(self, filename):
+        """
+        Initialisation of the qcow2 header analysis.
+
+        Parameters
+        ----------
+        filename: str
+            Full path of the qcow2 image file.
+        """
+        _logger.debug('qcow2 header size: %d bytes' % self.head_size)
+        super(Qcow2Head, self).__init__(filename)
+        head_size = struct.calcsize(Qcow2Head.qcowhead_fmt)
+
+        try:
+            with open(self._fn, 'rb') as f:
+                head_bin = f.read(head_size)
+                _logger.debug('%s header successfully read' % self._fn)
+        except Exception as e:
+            _logger.critical(
+                'Failed to read header of %s: %s' % (self._fn, str(e)))
+            raise OciMigrateException(
+                'Failed to read the header of %s: %s' % (self._fn, str(e)))
+
+        qcow2header = struct.unpack(Qcow2Head.qcowhead_fmt, head_bin)
+
+        self.stat = os.stat(self._fn)
+        self.img_tag = os.path.splitext(os.path.split(self._fn)[1])[0]
+        self.qcowhead_dict = dict((name[2], qcow2header[i]) for i, name in
+                                  enumerate(Qcow2Head.header2_structure))
+        self.img_header = dict()
+        self.img_header['head'] = self.qcowhead_dict
+        migrate_tools.result_msg(msg='Got image %s header' % filename, result=True)
+
+    def show_header(self):
+        """
+        Lists the header contents formatted.
+
+        Returns
+        -------
+            No return value.
+        """
+        migrate_tools.result_msg(msg='\n  %30s\n  %30s'
+                                 % ('QCOW2 file header data', '-'*30),
+                             result=False)
+        for f in Qcow2Head.header2_structure:
+            migrate_tools.result_msg(msg=''.join(["  %-30s" % f[2], f[1]
+                                              % self.qcowhead_dict[f[2]]]),
+                                 result=False)
+
+    def image_size(self):
+        """
+        Get the size of the image file.
+
+        Returns
+        -------
+            tuple: (float, float)
+                physical file size, logical file size
+        """
+
+        img_sz = {'physical': float(self.stat.st_size)/gigabyte,
+                  'logical': float(self.qcowhead_dict['size'])/gigabyte}
+
+        migrate_tools.result_msg(
+            msg='Image size: physical %10.2f GB, logical %10.2f GB' %
+            (img_sz['physical'], img_sz['logical']), result=True)
+        return img_sz
+
+    def image_supported(self, image_defs):
+        """
+        Verifies if the image file is supported for migration to the Oracle
+        cloud infrastructure.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+            str:  Eventual message on success or failure.
+        """
+        supp = True
+        prerequisites = image_defs['prereq']
+        msg = ''
+        sizes = self.image_size()
+        if sizes['logical'] > prerequisites['MAX_IMG_SIZE_GB']:
+            msg += 'Size of the image %.2f GB exceeds the maximum allowed ' \
+                   'size of %.2f GB.\n' % \
+                   (sizes['logical'], prerequisites['MAX_IMG_SIZE_GB'])
+            supp = False
+        else:
+            msg += 'Image size of %.2f GB below maximum allowed size ' \
+                   'of %.2f GB, OK.\n' % \
+                   (sizes['logical'], prerequisites['MAX_IMG_SIZE_GB'])
+        return supp, msg
+
+    def image_data(self):
+        """
+        Collect data about contents of the image file.
+
+        Returns
+        -------
+            bool: True on success, False otherwise;
+            dict: The image data.
+        """
+        _logger.debug('image data: %s' % self._fn)
+        # self.devicename = None
+        #
+        # initialise the dictionary for the image data
+        self._img_info['img_name'] = self._fn
+        self._img_info['img_type'] = 'qcow2'
+        self._img_info['img_header'] = self.img_header
+        self._img_info['img_size'] = self.image_size()
+        #
+        # mount the image using the nbd.
+        try:
+            result = self.handle_image()
+        except Exception as e:
+            _logger.critical('ERROR %s' % str(e))
+            raise OciMigrateException(str(e))
+        return result, self._img_info
+
+    def type_specific_prereq_test(self):
+        """
+        Verify the prerequisites specific for the image type from the header.
+
+        Returns
+        -------
+            bool: True or False.
+            str : Message
+        """
+        prereqs = format_data['514649fb']['prereq']
+        failmsg = ''
+        #
+        # size:
+        thispass = True
+        if self._img_info['img_size']['logical'] > prereqs['MAX_IMG_SIZE_GB']:
+            _logger.critical(
+                'Image size %8.2f GB exceeds maximum allowed %8.2f GB'
+                % (prereqs['MAX_IMG_SIZE_GB'],
+                   self._img_info['img_size']['logical']))
+            failmsg += '\n  Image size %8.2f GB exceeds maximum allowed ' \
+                       '%8.2f GB' % (prereqs['MAX_IMG_SIZE_GB'],
+                                     self._img_info['img_size']['logical'])
+            thispass = False
+        else:
+            failmsg += '\n  Image size %8.2f GB meets maximum allowed size ' \
+                       'of %8.2f GB' % (self._img_info['img_size']['logical'],
+                                        prereqs['MAX_IMG_SIZE_GB'])
+
+        return thispass, failmsg

--- a/lib/oci_utils/migrate/qcow2.py
+++ b/lib/oci_utils/migrate/qcow2.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 
@@ -124,11 +124,11 @@ class Qcow2Head(DeviceData):
         """
         migrate_tools.result_msg(msg='\n  %30s\n  %30s'
                                  % ('QCOW2 file header data', '-'*30),
-                             result=False)
+                                 result=False)
         for f in Qcow2Head.header2_structure:
             migrate_tools.result_msg(msg=''.join(["  %-30s" % f[2], f[1]
-                                              % self.qcowhead_dict[f[2]]]),
-                                 result=False)
+                                                  % self.qcowhead_dict[f[2]]]),
+                                    result=False)
 
     def image_size(self):
         """
@@ -212,7 +212,7 @@ class Qcow2Head(DeviceData):
         failmsg = ''
         #
         # size:
-        thispass = True
+        passed_requirement = True
         if self._img_info['img_size']['logical'] > prereqs['MAX_IMG_SIZE_GB']:
             _logger.critical(
                 'Image size %8.2f GB exceeds maximum allowed %8.2f GB'
@@ -221,10 +221,10 @@ class Qcow2Head(DeviceData):
             failmsg += '\n  Image size %8.2f GB exceeds maximum allowed ' \
                        '%8.2f GB' % (prereqs['MAX_IMG_SIZE_GB'],
                                      self._img_info['img_size']['logical'])
-            thispass = False
+            passed_requirement = False
         else:
             failmsg += '\n  Image size %8.2f GB meets maximum allowed size ' \
                        'of %8.2f GB' % (self._img_info['img_size']['logical'],
                                         prereqs['MAX_IMG_SIZE_GB'])
 
-        return thispass, failmsg
+        return passed_requirement, failmsg

--- a/lib/oci_utils/migrate/readme.txt
+++ b/lib/oci_utils/migrate/readme.txt
@@ -1,0 +1,86 @@
+#
+# definition of supported image formats:
+# dictionary of dictionaries,
+#  main key is the magic number,
+#    the format dictinary contains at least the name,
+#                                           the module name (without the .py extension)
+#                                           the class to be used
+                                            the class dependent prerequisites
+
+supported_formats = {'514649fb': {'name': 'qcow2',
+                                  'mod': 'qcow2',
+                                  'clazz': 'Qcow2Head',
+                                  'prereq': {'MAX_IMG_SIZE' : 300.0,}},
+                     '4b444d56': {'name': 'vmdk',
+                                  'mod': 'vmdk',
+                                  'clazz': 'VmdkHead',
+                                  'prereq': {'MAX_IMG_SIZE' : 300.0,
+                                            'vmdk_supported_types' :['monolithicSparse', 'streamOptimized']}}}
+
+#
+# the data collection:
+ device_data  img_name   <image file name>
+
+              img_type   [VMDK | qcow2]
+
+              img_header <contents is type dependent>
+
+              img_size  physical
+                        logical
+
+              mbr    bin
+                     hex
+                     valid (bool)
+                     partition_table [ {boot, type} ...]
+
+              parted Model
+                     Disk
+                     Partition Table
+
+              partitions /dev/nbd<n>p<m>  start
+                                          size
+                                          id
+                                          bootable
+                                          ID_FS_LABEL
+                                          ID_FS_LABEL_ENC
+                                          ID_FS_TYPE
+                                          ID_FS_USAGE
+                                          ID_FS_UUID
+                                          ID_FS_UUID_ENC
+                                          ID_FS_VERSION
+                                          ID_PART_ENTRY_DISK
+                                          ID_PART_ENTRY_NUMBER
+                                          ID_PART_ENTRY_OFFSET
+                                          ID_PART_ENTRY_SCHEME
+                                          ID_PART_ENTRY_SIZE
+                                          ID_PART_ENTRY_TYPE
+                                          mountpoint
+                                          usage [na| standard| boot| root]
+
+                         /dev/nbd<n>p<m>  ....
+
+                         /dev/mapper/<..> ...
+                          ....
+              volume_groups volume_group [ (logical volume, lv mapper), (logical volume, lv mapper),...]
+                            ...
+
+              osinformation NAME
+                            VERSION
+                            ....
+                            ....
+
+              bootmnt  (boot partition, <current mountpoint of the boot partition>)
+
+              rootmnt  (root partition, <current mountpoint of the root partition>)
+
+              boot_type [BIOS|UEFI|NA]
+
+              fstab  (list of relevant fstab line as lists)
+
+              grubdata [ { cnt { menuentry : [ menuentry list] { search : [search list ] ... }       ]
+
+              pseudomountlist [ list of mountpoints of pseudofs ]
+
+              remountlist [ list of mounts root and swap excluded ]
+
+              ostype <ref to os dependent code>

--- a/lib/oci_utils/migrate/reconfigure_network.py
+++ b/lib/oci_utils/migrate/reconfigure_network.py
@@ -1,0 +1,551 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+""" 
+Module containing methods for the configuration of the networking with
+respect to upload to the Oracle Cloud Infrastructure.
+"""
+import logging
+import os
+import shutil
+import six
+import stat
+import yaml
+
+from glob import glob
+from oci_utils.migrate import get_config_data
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.exception import OciMigrateException
+from six.moves import configparser
+
+_logger = logging.getLogger('oci-utils.reconfigure-network')
+ConfigParser = configparser.ConfigParser
+
+
+def reconfigure_ifcfg_config(rootdir):
+    """
+    Modify the network configuration in the image file to prevent
+    conflicts during import. This is only for ol-type linux.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir as loopback mounted.
+
+    Returns
+    -------
+        list: list of nic.
+        dict: the interfaces configuration.
+    """
+    #
+    # Rename the config files
+    _logger.debug('The network ifcfg configuration.')
+    ifcfg_list = list()
+    ifcfg_data = dict()
+    ifrootdir = rootdir + get_config_data('default_ifcfg')
+    if migrate_tools.dir_exists(ifrootdir):
+        for cfgfile in glob(ifrootdir + '/ifcfg-*'):
+            _logger.debug('Checking configfile: %s' % cfgfile)
+            try:
+                with open(cfgfile, 'rb') as f:
+                    nl = filter(None, [x[:x.find('#')] for x in f])
+                ifcfg = dict(l.translate(None, '"').split('=') for l in nl)
+                if 'DEVICE' in ifcfg:
+                    devname = ifcfg['DEVICE']
+                else:
+                    _logger.debug('Missing device name in %s' % cfgfile)
+                    devname = cfgfile.split('/')[-1]
+                ifcfg_list.append(devname)
+                ifcfg_data[devname] = ifcfg
+                _logger.debug('Network interface: %s' % devname)
+            except Exception as e:
+                _logger.error('Problem reading network configuration file %s: '
+                             '%s' % (cfgfile, str(e)))
+    else:
+        _logger.debug('No ifcfg network configuration.')
+    #
+    # backup
+    for fn in glob(ifrootdir + '/ifcfg-*'):
+        if 'ifcfg-lo' not in fn:
+            fn_bck = os.path.split(fn)[0] \
+                     + '/bck_' \
+                     + os.path.split(fn)[1] \
+                     + '_' \
+                     + migrate_tools.thistime
+            if migrate_tools.exec_rename(fn, fn_bck):
+                _logger.debug('Network config file %s successfully '
+                             'renamed to %s' % (fn, fn_bck))
+            else:
+                migrate_tools.error_msg('Failed to backup network configuration '
+                                    'file %s to %s.' % (fn, fn_bck))
+                raise OciMigrateException('Failed to rename network config '
+                                          'file %s to %s' % (fn, fn_bck))
+        else:
+            _logger.debug('ifcfg-lo found.')
+    #
+    # Generate new default network configuration.
+    if len(ifcfg_list) > 0:
+        nic0 = sorted(ifcfg_list)[0]
+        dhcpniccfg = ifrootdir + '/ifcfg-%s' % nic0
+        _logger.debug('Replacing network config file %s' % dhcpniccfg)
+        try:
+            with open(dhcpniccfg, 'wb') as f:
+                f.writelines(ln.replace('_XXXX_', nic0) + '\n'
+                             for ln in get_config_data('default_ifcfg_config'))
+            migrate_tools.result_msg(msg='Replaced ifcfg network configuration.',
+                                     result=True)
+        except Exception as e:
+            _logger.error('Failed to write %s/ifcfg-eth0' % ifrootdir)
+            migrate_tools.error_msg('Failed to write %s: %s' % (dhcpniccfg, str(e)))
+            raise OciMigrateException('Failed to write %s: %s'
+                                      % (dhcpniccfg, str(e)))
+    else:
+        _logger.debug('No ifcfg definitions found.')
+    #
+    return ifcfg_list, ifcfg_data
+
+
+def reconfigure_netplan(rootdir):
+    """
+    Parse the yaml netplan files and look for network interface names.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir as loopback mounted.
+
+    Returns
+    -------
+        list: list of nic.
+        dict: the netplan network configurations.
+    """
+
+    _logger.debug('The netplan configuration.')
+    netplan_data = dict()
+    netplan_nics = list()
+    thisroot = rootdir + get_config_data('default_netplan')
+    if migrate_tools.dir_exists(thisroot):
+        _logger.debug('netplan directory exists.')
+        #
+        # contains yaml files?
+        yaml_files = glob(thisroot + '/*.yaml')
+        if len(yaml_files) > 0:
+            for yf in sorted(yaml_files):
+                try:
+                    with open(yf, 'r') as yfd:
+                        thisyaml = yaml.safe_load(yfd)
+                        netplan_data[yf] = thisyaml
+                        _logger.debug('netplan: %s' % thisyaml)
+                except Exception as e:
+                    _logger.error('Failed to parse %s: %s' % (yf, str(e)))
+                    migrate_tools.error_msg('Failed to parse %s: %s' % (yf, str(e)))
+                    break
+                #
+                if 'network' in thisyaml:
+                    if 'ethernets' in thisyaml['network']:
+                        for k,_ in sorted(
+                                six.iteritems(thisyaml['network']['ethernets'])
+                                ):
+                            netplan_nics.append(k)
+                    else:
+                        _logger.debug('ethernets key missing.')
+                else:
+                    _logger.debug('network key missing.')
+            if len(netplan_nics) == 0:
+                _logger.debug('No netplan definitions found in %s' % thisroot)
+            else:
+                nicname = sorted(netplan_nics)[0]
+                #
+                # rename and recreate
+                try:
+                    #
+                    # backup
+                    migrate_tools.exec_rename(thisroot, os.path.split(thisroot)[0]
+                                          + '/bck_'
+                                          + os.path.split(thisroot)[1]
+                                          + '_'
+                                          + migrate_tools.thistime)
+                    #
+                    # recreate dir
+                    os.mkdir(thisroot)
+                    mode755 = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | \
+                              stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | \
+                              stat.S_IROTH
+                    os.chmod(thisroot, mode755)
+                    #
+                    # recreate netplan config
+                    this_netplan = get_config_data('default_netplan_config')
+                    this_netplan['network']['ethernets'][nicname] \
+                        = this_netplan['network']['ethernets'].pop('_XXXX_')
+                    with open(thisroot + '/'
+                              + get_config_data('default_netplan_file'), 'w') \
+                            as yf:
+                        yaml.safe_dump(this_netplan, yf, default_flow_style=False)
+                    migrate_tools.result_msg(msg='Netplan network configuration '
+                                             'files replaced.', result=True)
+                except Exception as e:
+                    migrate_tools.error_msg('Failed to write new netplan '
+                                        'configuration file %s: %s'
+                                        % (get_config_data('default_netplan_file'), str(e)))
+                    raise OciMigrateException('Failed to write new netplan '
+                                              'configuration file %s: %s'
+                                              % (get_config_data('default_netplan_file'), str(e)))
+        else:
+            _logger.error('No netplan yaml config files found.')
+    else:
+        _logger.debug('No netplan configuration found.')
+
+    return netplan_nics, netplan_data
+
+
+def reconfigure_networkmanager(rootdir):
+    """
+    Replace the networkmanager configuration with Oracle Cloud Infrastructure
+    compatible version.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir as loopback mounted.
+    Returns
+    -------
+        list: list of nic.
+        dict: the network manager system-connections configurations
+    """
+    _logger.debug('The NetworkManager configuration.')
+    netwmg_data = dict()
+    netwmg_nics = list()
+    thisdir = rootdir + get_config_data('default_nwconnections')
+    _logger.debug('Network manager dir: %s' % thisdir)
+    thiscfg = rootdir + get_config_data('default_nwmconfig')
+    _logger.debug('Network manager conf: %s' % thiscfg)
+    #
+    # backup
+    try:
+        #
+        # copy
+        if migrate_tools.file_exists(thiscfg):
+            _logger.debug('Copy %s %s' % (thiscfg, os.path.split(thiscfg)[0]
+                                          + '/bck_'
+                                          + os.path.split(thiscfg)[1]
+                                          + '_'
+                                          + migrate_tools.thistime))
+            shutil.copy(thiscfg, os.path.split(thiscfg)[0]
+                        + '/bck_'
+                        + os.path.split(thiscfg)[1]
+                        + '_'
+                        + migrate_tools.thistime)
+        else:
+            _logger.debug('No %s found.' % thiscfg)
+        if migrate_tools.dir_exists(thisdir):
+            _logger.debug('Copytree %s %s' % (thisdir, os.path.split(thisdir)[0]
+                                              + '/bck_'
+                                              + os.path.split(thisdir)[1]
+                                              + '_'
+                                              + migrate_tools.thistime))
+            shutil.copytree(thisdir, os.path.split(thisdir)[0]
+                            + '/bck_'
+                            + os.path.split(thisdir)[1]
+                            + '_'
+                            + migrate_tools.thistime)
+        else:
+            _logger.debug('%s not found.' % thisdir)
+    except Exception as e:
+        migrate_tools.error_msg('Failed to backup the networkmanager '
+                            'configuration: %s' % str(e))
+    #
+    #
+    if migrate_tools.dir_exists(thisdir):
+        _logger.debug('NetworkManager/%s directory exists.' % thisdir)
+        #
+        # contains nwm keyfiles?
+        nwm_files = glob(thisdir + '/*')
+        if len(nwm_files) > 0:
+            for nwkf in sorted(nwm_files):
+                thispars = ConfigParser()
+                netwmg_data[nwkf] = dict()
+                try:
+                    rv = thispars.read(nwkf)
+                    if 'connection' in thispars.sections():
+                        ifname = thispars.get('connection', 'interface-name')
+                        netwmg_nics.append(ifname)
+                    else:
+                        _logger.debug('No connection section in %s' % nwkf)
+
+                    for sec in thispars.sections():
+                        netwmg_data[nwkf][sec] = thispars.items(sec)
+                        _logger.debug('%s' % netwmg_data[nwkf][sec])
+                    #
+                    # remove macaddress ref
+                    if thispars.has_option('ethernet', 'mac-address'):
+                        thispars.remove_option('ethernet', 'mac-address')
+                        with open(nwkf, 'wb') as kf:
+                            thispars.write(kf)
+                        _logger.debug('Removed reference to mac address in %s' % nwkf)
+                    else:
+                        _logger.debug('No ethernet - mac-address section in %s'
+                                     % nwkf)
+                except Exception as e:
+                    _logger.error('Some error reading %s: %s' % (nwkf, str(e)))
+        else:
+            _logger.debug('No network manager keyfiles found.')
+        #
+        # update networkmanager configuration
+        if len(nwm_files) > 1:
+            #
+            # update unmanaged list
+            configpars = ConfigParser()
+            try:
+                rv = configpars.read(thiscfg)
+                if 'keyfile' not in configpars.sections():
+                    #
+                    # add section
+                    configpars.add_section('keyfile')
+                    _logger.debug('Added keyfile section.')
+                else:
+                    _logger.debug('keyfile section present.')
+                #
+                # unmanaged?
+                if configpars.has_option('keyfile', 'unmanaged-devices'):
+                    #
+                    # key is present, update
+                    unmdev = configpars.get('keyfile', 'unmanaged-devices')
+                    _logger.debug('Unmanaged devices found: %s' % unmdev)
+                    unmdev += ';' if unmdev is not '' else unmdev
+                else:
+                    #
+                    # add unmanaged-devices
+                    unmdev = ''
+
+                for nic in netwmg_nics[1:]:
+                    unmdev += 'interface-name:%s;' % nic \
+                        if 'interface-name:%s' % nic not in unmdev else unmdev
+                unmdev = unmdev[:-1] if unmdev[-1:] == ';' else unmdev
+
+                configpars.set('keyfile', 'unmanaged-devices', '%s' % unmdev)
+                _logger.debug('Added %s to unmanaged interface list.' % unmdev)
+                with open(thiscfg, 'wb') as nwc:
+                    configpars.write(nwc)
+                _logger.debug('Updated network manager config file %s' % thiscfg)
+            except Exception as e:
+                migrate_tools.error_msg('Error rewriting network manager '
+                                    'configuration file: %s' % str(e))
+        else:
+            migrate_tools.result_msg(msg='Networkmanager configuration updated.',
+                          result=True)
+            _logger.debug('Zero or 1 network interface defined.')
+    else:
+        _logger.debug(msg='  No NetworkManager configuration present.')
+
+    return netwmg_nics, netwmg_data
+
+
+def reconfigure_interfaces(rootdir):
+    """
+    Parse the network interfaces file.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir as loopback mounted.
+
+    Returns
+    -------
+        list: list of nic.
+        dict: the interfaces configuration.
+    """
+    _logger.debug('The network interfaces configuration.')
+    int_data = dict()
+    int_nics = list()
+    thisroot = rootdir + get_config_data('default_interfaces')
+    thisinterfaces = thisroot + '/interfaces'
+
+    if migrate_tools.file_exists(thisinterfaces):
+        int_data[get_config_data('default_interfaces')] = list()
+        _logger.debug('%s file exists' % thisinterfaces)
+        try:
+            with open(thisinterfaces, 'r') as inf:
+                for ln in inf:
+                    int_data[get_config_data('default_interfaces')].append(ln)
+                    if 'iface' in ln.split():
+                        if ln.split()[1] != 'lo':
+                            int_nics.append(ln.split()[1])
+                    else:
+                        _logger.debug('no iface in %s' % ln)
+        except Exception as e:
+            _logger.error('Error occured while reading %s: %s'
+                         % (thisinterfaces, str(e)))
+        #
+        # rewrite
+        if len(int_nics) == 0:
+            _logger.debug('No interface definitions found in %s' %
+                          thisinterfaces)
+        else:
+            try:
+                #
+                # backup
+                _logger.debug('Copytree %s %s' % (thisroot, os.path.split(thisroot)[0]
+                                                  + '/bck_'
+                                                  + os.path.split(thisroot)[1]
+                                                  + migrate_tools.thistime))
+                shutil.copytree(thisroot, os.path.split(thisroot)[0]
+                                + '/bck_'
+                                + os.path.split(thisroot)[1]
+                                + migrate_tools.thistime)
+                #
+                # remove dir
+                shutil.rmtree(thisroot + '/interfaces.d')
+                #
+                # recreate interfaces config
+                with open(thisinterfaces, 'w') as fi:
+                    fi.writelines(ln.replace('_XXXX_', int_nics[0]) + '\n'
+                                  for ln in get_config_data('default_interfaces_config'))
+                migrate_tools.result_msg(msg='Network interfaces file rewritten.',
+                                     result=True)
+            except Exception as e:
+                _logger.error('Failed to write new interfaces configuration '
+                             'file %s: %s' % (thisinterfaces, str(e)))
+    else:
+        _logger.debug('No network interfaces configuration.')
+    return int_nics, int_data
+
+
+def reconfigure_systemd_networkd(rootdir):
+    """
+    Parse the systemd network configuration.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir as loopback mounted.
+
+    Returns
+    -------
+        list: list of nic.
+        dict: the interfaces configuration.
+    """
+    _logger.debug('The network systemd-networkd configuration.')
+    sys_data = dict()
+    sys_nics = list()
+    nw_ignore = ['container-host0', 'container-ve', 'container-vz']
+
+    for thisroot in get_config_data('default_systemd'):
+        networkd_root = rootdir + thisroot
+        if migrate_tools.dir_exists(networkd_root):
+            _logger.debug('systemd network directory exists.')
+            systemd_files = glob(thisroot + '/*.network')
+            if len(systemd_files) > 0:
+                for sf in sorted(systemd_files):
+                    ignore = False
+                    for ig in nw_ignore:
+                        if ig in sf:
+                            ignore = True
+                            break
+                    if not ignore:
+                        thispars = ConfigParser()
+                        sys_data[sf] = dict()
+                        try:
+                            sv = thispars.read(sf)
+                            if 'Match' in thispars.sections():
+                                ifname = thispars.get('Match', 'Name')
+                                sys_nics.append(ifname)
+                            else:
+                                _logger.debug('-- No Match section in %s' % sf)
+                            #
+                            for sec in thispars.sections():
+                                sys_data[sf][sec] = thispars.items(sec)
+                                _logger.debug('%s' % sys_data[sf][sec])
+                        except Exception as e:
+                            _logger.error('Failed to parse %s: %s' % (sf, str(e)))
+                        #
+                        # rename - backup
+                        bcknm = os.path.split(sf)[0] + '/bck_' \
+                                + os.path.split(sf)[1] + '_' \
+                                + migrate_tools.thistime
+                        if migrate_tools.exec_rename(sf, bcknm):
+                            _logger.debug('Network config file %s renamed to %s'
+                                          % (sf, bcknm))
+                            _logger.debug('Network config file %s successfully '
+                                         'renamed to %s'
+                                         % (sf, os.path.split(sf)[0]
+                                            + '/bck' + os.path.split(sf)[1]
+                                            + '_bck'))
+                        else:
+                            _logger.error('Failed to rename %s to %s'
+                                         % (sf, os.path.split(sf)[0]
+                                            + '/bck'
+                                            + os.path.split(sf)[1]
+                                            + '_bck'))
+                            raise OciMigrateException('Failed to rename %s '
+                                                      'to %s' % (sf, bcknm))
+            else:
+                _logger.debug('No systemd-networkd configuration.')
+        else:
+            _logger.debug('%s does not exist.'
+                         % get_config_data('default_systemd'))
+    #
+    # write new config
+    if len(sys_nics) > 0:
+        nicname = sorted(sys_nics)[0]
+        with open(rootdir + get_config_data('default_systemd_file'), 'w') as sdf:
+            sdf.writelines(ln.replace('_XXXX_', nicname) + '\n'
+                           for ln in get_config_data('default_systemd_config'))
+        migrate_tools.result_msg(msg='systemd-networkd configuration rewritten.',
+                             result=True)
+    else:
+        _logger.debug('No systemd-networkd configuration.')
+    return sorted(sys_nics), sys_data
+
+
+def update_network_config(rootdir):
+    """
+    Modify the network configuration in the image file to prevent conflicts
+    during import. Currently
+    ifcfg, NetworkManager, netplan, network connections systemd-networkd and
+    interface
+    file are scanned. Bonding and bridging are not supported for now,
+    nor multiple ip per interface.
+
+    Parameters
+    ----------
+    rootdir: str
+        Full path of image root dir.
+
+    Returns
+    -------
+        dict: List with dictionary representation of the network
+        configuration files.
+    """
+    migrate_tools.result_msg(msg='Adjust network configuration.', result=True)
+    network_config = dict()
+    network_list = list()
+    #
+    # ifcfg
+    ifcfg_nics, ifcfg_data = reconfigure_ifcfg_config(rootdir)
+    network_list += ifcfg_nics
+    network_config['ifcfg'] = ifcfg_data
+    #
+    # netplan
+    netplan_nics, netplan_data = reconfigure_netplan(rootdir)
+    network_list += netplan_nics
+    network_config['netplan'] = netplan_data
+    #
+    # network manager
+    nwmg_nics, nwmg_data = reconfigure_networkmanager(rootdir)
+    network_list += nwmg_nics
+    network_config['network_manager'] = nwmg_data
+    #
+    # interfaces
+    int_list, int_data = reconfigure_interfaces(rootdir)
+    network_list += int_list
+    network_config['interfaces'] = int_data
+    #
+    # systemd
+    netsys_nics, netsys_data = reconfigure_systemd_networkd(rootdir)
+    network_list += netsys_nics
+    network_config['systemd-networkd'] = netsys_data
+
+    return network_list, network_config

--- a/lib/oci_utils/migrate/reconfigure_network.py
+++ b/lib/oci_utils/migrate/reconfigure_network.py
@@ -13,7 +13,7 @@ import fnmatch
 import os
 import re
 import shutil
-import six
+import configparser
 import stat
 import yaml
 
@@ -22,7 +22,6 @@ from oci_utils.migrate import get_config_data
 from oci_utils.migrate import migrate_tools
 from oci_utils.migrate import migrate_utils
 from oci_utils.migrate.exception import OciMigrateException
-from six.moves import configparser
 
 _logger = logging.getLogger('oci-utils.reconfigure-network')
 ConfigParser = configparser.ConfigParser
@@ -44,15 +43,15 @@ def cleanup_udev(rootdir):
     _logger.debug('Update network udev rules.')
     udevrootdir = rootdir + '/etc/udev'
     _logger.debug('udev root is %s' % udevrootdir)
-    pregex=fnmatch.translate('*rules')
-    rulefiles=[]
-    if migrate_tools.dir_exists(udevrootdir):
+    pregex = fnmatch.translate('*rules')
+    rulefiles = []
+    if os.path.isdir(udevrootdir):
         #
         # Backup
         shutil.copytree(udevrootdir, os.path.split(udevrootdir)[0] + '/bck_'
                         + os.path.split(udevrootdir)[1]
                         + '_'
-                        + migrate_tools.thistime)
+                        + migrate_tools.current_time)
 
         for root, dirs, files in os.walk(udevrootdir):
             for fn in files:
@@ -62,7 +61,7 @@ def cleanup_udev(rootdir):
                 if re.search(pregex, fullfn):
                     rulefiles.append(fullfn)
                     macmatch = False
-                    with open(fullfn, 'rb') as g:
+                    with open(fullfn, 'r') as g:
                         #
                         # Look for network naming rules
                         for line in g:
@@ -76,8 +75,8 @@ def cleanup_udev(rootdir):
                         mv_fullfn = fullfn + '_save'
                         try:
                             shutil.move(fullfn, mv_fullfn)
-                            fndata = open(mv_fullfn, 'rb').read()
-                            newf = open(fullfn, 'wb')
+                            fndata = open(mv_fullfn, 'r').read()
+                            newf = open(fullfn, 'w')
                             for lx in fndata.split('\n'):
                                 if not re.match("(.*)KERNEL==\"eth(.*)", lx):
                                     newf.write('%s\n' % lx)
@@ -113,13 +112,14 @@ def reconfigure_ifcfg_config(rootdir):
     ifcfg_list = list()
     ifcfg_data = dict()
     ifrootdir = rootdir + get_config_data('default_ifcfg')
-    if migrate_tools.dir_exists(ifrootdir):
+    if os.path.isdir(ifrootdir):
         for cfgfile in glob(ifrootdir + '/ifcfg-*'):
             _logger.debug('Checking configfile: %s' % cfgfile)
             try:
-                with open(cfgfile, 'rb') as f:
-                    nl = filter(None, [x[:x.find('#')] for x in f])
-                ifcfg = dict(l.translate(None, '"').split('=') for l in nl)
+                with open(cfgfile, 'r') as f:
+                    # nl = filter(None, [x[:x.find('#')] for x in f])
+                    nl = [_f for _f in [x[:x.find('#')] for x in f] if _f]
+                ifcfg = dict(dl.replace('"', '').split('=') for dl in nl)
                 if 'DEVICE' in ifcfg:
                     devname = ifcfg['DEVICE']
                 else:
@@ -130,7 +130,7 @@ def reconfigure_ifcfg_config(rootdir):
                 _logger.debug('Network interface: %s' % devname)
             except Exception as e:
                 _logger.error('Problem reading network configuration file %s: '
-                             '%s' % (cfgfile, str(e)))
+                              '%s' % (cfgfile, str(e)))
     else:
         _logger.debug('No ifcfg network configuration.')
     #
@@ -141,13 +141,13 @@ def reconfigure_ifcfg_config(rootdir):
                      + '/bck_' \
                      + os.path.split(fn)[1] \
                      + '_' \
-                     + migrate_tools.thistime
+                     + migrate_tools.current_time
             if migrate_tools.exec_rename(fn, fn_bck):
                 _logger.debug('Network config file %s successfully '
-                             'renamed to %s' % (fn, fn_bck))
+                              'renamed to %s' % (fn, fn_bck))
             else:
                 migrate_tools.error_msg('Failed to backup network configuration '
-                                    'file %s to %s.' % (fn, fn_bck))
+                                        'file %s to %s.' % (fn, fn_bck))
                 raise OciMigrateException('Failed to rename network config '
                                           'file %s to %s' % (fn, fn_bck))
         else:
@@ -159,7 +159,7 @@ def reconfigure_ifcfg_config(rootdir):
         dhcpniccfg = ifrootdir + '/ifcfg-%s' % nic0
         _logger.debug('Replacing network config file %s' % dhcpniccfg)
         try:
-            with open(dhcpniccfg, 'wb') as f:
+            with open(dhcpniccfg, 'w') as f:
                 f.writelines(ln.replace('_XXXX_', nic0) + '\n'
                              for ln in get_config_data('default_ifcfg_config'))
             migrate_tools.result_msg(msg='Replaced ifcfg network configuration.',
@@ -193,36 +193,34 @@ def reconfigure_netplan(rootdir):
     _logger.debug('The netplan configuration.')
     netplan_data = dict()
     netplan_nics = list()
-    thisroot = rootdir + get_config_data('default_netplan')
-    if migrate_tools.dir_exists(thisroot):
+    root_path = rootdir + get_config_data('default_netplan')
+    if os.path.isdir(root_path):
         _logger.debug('netplan directory exists.')
         #
         # contains yaml files?
-        yaml_files = glob(thisroot + '/*.yaml')
+        yaml_files = glob(root_path + '/*.yaml')
         if len(yaml_files) > 0:
             for yf in sorted(yaml_files):
                 try:
                     with open(yf, 'r') as yfd:
-                        thisyaml = yaml.safe_load(yfd)
-                        netplan_data[yf] = thisyaml
-                        _logger.debug('netplan: %s' % thisyaml)
+                        yaml_data = yaml.safe_load(yfd)
+                        netplan_data[yf] = yaml_data
+                        _logger.debug('netplan: %s' % yaml_data)
                 except Exception as e:
                     _logger.error('Failed to parse %s: %s' % (yf, str(e)))
                     migrate_tools.error_msg('Failed to parse %s: %s' % (yf, str(e)))
                     break
                 #
-                if 'network' in thisyaml:
-                    if 'ethernets' in thisyaml['network']:
-                        for k,_ in sorted(
-                                six.iteritems(thisyaml['network']['ethernets'])
-                                ):
+                if 'network' in yaml_data:
+                    if 'ethernets' in yaml_data['network']:
+                        for k,_ in sorted(yaml_data['network']['ethernets'].items()):
                             netplan_nics.append(k)
                     else:
                         _logger.debug('ethernets key missing.')
                 else:
                     _logger.debug('network key missing.')
             if len(netplan_nics) == 0:
-                _logger.debug('No netplan definitions found in %s' % thisroot)
+                _logger.debug('No netplan definitions found in %s' % root_path)
             else:
                 nicname = sorted(netplan_nics)[0]
                 #
@@ -230,33 +228,33 @@ def reconfigure_netplan(rootdir):
                 try:
                     #
                     # backup
-                    migrate_tools.exec_rename(thisroot, os.path.split(thisroot)[0]
-                                          + '/bck_'
-                                          + os.path.split(thisroot)[1]
-                                          + '_'
-                                          + migrate_tools.thistime)
+                    migrate_tools.exec_rename(root_path, os.path.split(root_path)[0]
+                                              + '/bck_'
+                                              + os.path.split(root_path)[1]
+                                              + '_'
+                                              + migrate_tools.current_time)
                     #
                     # recreate dir
-                    os.mkdir(thisroot)
+                    os.mkdir(root_path)
                     mode755 = stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH | \
                               stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | \
                               stat.S_IROTH
-                    os.chmod(thisroot, mode755)
+                    os.chmod(root_path, mode755)
                     #
                     # recreate netplan config
-                    this_netplan = get_config_data('default_netplan_config')
-                    this_netplan['network']['ethernets'][nicname] \
-                        = this_netplan['network']['ethernets'].pop('_XXXX_')
-                    with open(thisroot + '/'
+                    netplan_config = get_config_data('default_netplan_config')
+                    netplan_config['network']['ethernets'][nicname] \
+                        = netplan_config['network']['ethernets'].pop('_XXXX_')
+                    with open(root_path + '/'
                               + get_config_data('default_netplan_file'), 'w') \
                             as yf:
-                        yaml.safe_dump(this_netplan, yf, default_flow_style=False)
+                        yaml.safe_dump(netplan_config, yf, default_flow_style=False)
                     migrate_tools.result_msg(msg='Netplan network configuration '
                                              'files replaced.', result=True)
                 except Exception as e:
                     migrate_tools.error_msg('Failed to write new netplan '
-                                        'configuration file %s: %s'
-                                        % (get_config_data('default_netplan_file'), str(e)))
+                                            'configuration file %s: %s'
+                                            % (get_config_data('default_netplan_file'), str(e)))
                     raise OciMigrateException('Failed to write new netplan '
                                               'configuration file %s: %s'
                                               % (get_config_data('default_netplan_file'), str(e)))
@@ -285,65 +283,65 @@ def reconfigure_networkmanager(rootdir):
     _logger.debug('The NetworkManager configuration.')
     netwmg_data = dict()
     netwmg_nics = list()
-    thisdir = rootdir + get_config_data('default_nwconnections')
-    _logger.debug('Network manager dir: %s' % thisdir)
-    thiscfg = rootdir + get_config_data('default_nwmconfig')
-    _logger.debug('Network manager conf: %s' % thiscfg)
+    network_config_dir = rootdir + get_config_data('default_nwconnections')
+    _logger.debug('Network manager dir: %s' % network_config_dir)
+    nw_mgr_cfg = rootdir + get_config_data('default_nwmconfig')
+    _logger.debug('Network manager conf: %s' % nw_mgr_cfg)
     #
     # backup
     try:
         #
         # copy
-        if migrate_tools.file_exists(thiscfg):
-            _logger.debug('Copy %s %s' % (thiscfg, os.path.split(thiscfg)[0]
+        if os.path.isfile(nw_mgr_cfg):
+            _logger.debug('Copy %s %s' % (nw_mgr_cfg, os.path.split(nw_mgr_cfg)[0]
                                           + '/bck_'
-                                          + os.path.split(thiscfg)[1]
+                                          + os.path.split(nw_mgr_cfg)[1]
                                           + '_'
-                                          + migrate_tools.thistime))
-            shutil.copy(thiscfg, os.path.split(thiscfg)[0]
+                                          + migrate_tools.current_time))
+            shutil.copy(nw_mgr_cfg, os.path.split(nw_mgr_cfg)[0]
                         + '/bck_'
-                        + os.path.split(thiscfg)[1]
+                        + os.path.split(nw_mgr_cfg)[1]
                         + '_'
-                        + migrate_tools.thistime)
+                        + migrate_tools.current_time)
         else:
-            _logger.debug('No %s found.' % thiscfg)
-        if migrate_tools.dir_exists(thisdir):
-            _logger.debug('Copytree %s %s' % (thisdir, os.path.split(thisdir)[0]
+            _logger.debug('No %s found.' % nw_mgr_cfg)
+        if os.path.isdir(network_config_dir):
+            _logger.debug('Copytree %s %s' % (network_config_dir, os.path.split(network_config_dir)[0]
                                               + '/bck_'
-                                              + os.path.split(thisdir)[1]
+                                              + os.path.split(network_config_dir)[1]
                                               + '_'
-                                              + migrate_tools.thistime))
-            shutil.copytree(thisdir, os.path.split(thisdir)[0]
+                                              + migrate_tools.current_time))
+            shutil.copytree(network_config_dir, os.path.split(network_config_dir)[0]
                             + '/bck_'
-                            + os.path.split(thisdir)[1]
+                            + os.path.split(network_config_dir)[1]
                             + '_'
-                            + migrate_tools.thistime)
+                            + migrate_tools.current_time)
         else:
-            _logger.debug('%s not found.' % thisdir)
+            _logger.debug('%s not found.' % network_config_dir)
     except Exception as e:
         migrate_tools.error_msg('Failed to backup the networkmanager '
-                            'configuration: %s' % str(e))
+                                'configuration: %s' % str(e))
     #
     #
-    if migrate_tools.dir_exists(thisdir):
-        _logger.debug('NetworkManager/%s directory exists.' % thisdir)
+    if os.path.isdir(network_config_dir):
+        _logger.debug('NetworkManager/%s directory exists.' % network_config_dir)
         #
         # contains nwm keyfiles?
-        nwm_files = glob(thisdir + '/*')
+        nwm_files = glob(network_config_dir + '/*')
         if len(nwm_files) > 0:
-            migrate_utils.exec_rmdir(thisdir)
-            migrate_utils.exec_mkdir(thisdir)
-            _logger.debug('%s emptied.' % thisdir)
+            migrate_utils.exec_rmdir(network_config_dir)
+            migrate_utils.exec_mkdir(network_config_dir)
+            _logger.debug('%s emptied.' % network_config_dir)
         else:
             _logger.debug('No network manager keyfiles found.')
         #
         # update networkmanager configuration
         # TODO: write config file with configparser
         nwm_config_data = get_config_data('default_nwm_conf_file')
-        with open(thiscfg, 'w') as nwmf:
+        with open(nw_mgr_cfg, 'w') as nwmf:
             nwmf.write('\n'.join(str(x) for x in nwm_config_data))
             migrate_tools.result_msg(msg='Networkmanager configuration updated.',
-                          result=True)
+                                     result=True)
     else:
         _logger.debug(msg='  No NetworkManager configuration present.')
 
@@ -367,14 +365,14 @@ def reconfigure_interfaces(rootdir):
     _logger.debug('The network interfaces configuration.')
     int_data = dict()
     int_nics = list()
-    thisroot = rootdir + get_config_data('default_interfaces')
-    thisinterfaces = thisroot + '/interfaces'
+    root_path = rootdir + get_config_data('default_interfaces')
+    net_ifcfg_config = root_path + '/interfaces'
 
-    if migrate_tools.file_exists(thisinterfaces):
+    if os.path.isfile(net_ifcfg_config):
         int_data[get_config_data('default_interfaces')] = list()
-        _logger.debug('%s file exists' % thisinterfaces)
+        _logger.debug('%s file exists' % net_ifcfg_config)
         try:
-            with open(thisinterfaces, 'r') as inf:
+            with open(net_ifcfg_config, 'r') as inf:
                 for ln in inf:
                     int_data[get_config_data('default_interfaces')].append(ln)
                     if 'iface' in ln.split():
@@ -384,38 +382,38 @@ def reconfigure_interfaces(rootdir):
                         _logger.debug('no iface in %s' % ln)
         except Exception as e:
             _logger.error('Error occured while reading %s: %s'
-                         % (thisinterfaces, str(e)))
+                          % (net_ifcfg_config, str(e)))
         #
         # rewrite
         if len(int_nics) == 0:
             _logger.debug('No interface definitions found in %s' %
-                          thisinterfaces)
+                          net_ifcfg_config)
         else:
             try:
                 #
                 # backup
-                _logger.debug('Copytree %s %s' % (thisroot, os.path.split(thisroot)[0]
+                _logger.debug('Copytree %s %s' % (root_path, os.path.split(root_path)[0]
                                                   + '/bck_'
-                                                  + os.path.split(thisroot)[1]
-                                                  + migrate_tools.thistime))
-                shutil.copytree(thisroot, os.path.split(thisroot)[0]
+                                                  + os.path.split(root_path)[1]
+                                                  + migrate_tools.current_time))
+                shutil.copytree(root_path, os.path.split(root_path)[0]
                                 + '/bck_'
-                                + os.path.split(thisroot)[1]
+                                + os.path.split(root_path)[1]
                                 + '_'
-                                + migrate_tools.thistime)
+                                + migrate_tools.current_time)
                 #
                 # remove dir
-                shutil.rmtree(thisroot + '/interfaces.d')
+                shutil.rmtree(root_path + '/interfaces.d')
                 #
                 # recreate interfaces config
-                with open(thisinterfaces, 'w') as fi:
+                with open(net_ifcfg_config, 'w') as fi:
                     fi.writelines(ln.replace('_XXXX_', int_nics[0]) + '\n'
                                   for ln in get_config_data('default_interfaces_config'))
                 migrate_tools.result_msg(msg='Network interfaces file rewritten.',
-                                     result=True)
+                                         result=True)
             except Exception as e:
                 _logger.error('Failed to write new interfaces configuration '
-                             'file %s: %s' % (thisinterfaces, str(e)))
+                              'file %s: %s' % (net_ifcfg_config, str(e)))
     else:
         _logger.debug('No network interfaces configuration.')
     return int_nics, int_data
@@ -440,11 +438,11 @@ def reconfigure_systemd_networkd(rootdir):
     sys_nics = list()
     nw_ignore = ['container-host0', 'container-ve', 'container-vz']
 
-    for thisroot in get_config_data('default_systemd'):
-        networkd_root = rootdir + thisroot
-        if migrate_tools.dir_exists(networkd_root):
+    for root_path in get_config_data('default_systemd'):
+        networkd_root = rootdir + root_path
+        if os.path.isdir(networkd_root):
             _logger.debug('systemd network directory exists.')
-            systemd_files = glob(thisroot + '/*.network')
+            systemd_files = glob(root_path + '/*.network')
             if len(systemd_files) > 0:
                 for sf in sorted(systemd_files):
                     ignore = False
@@ -453,37 +451,37 @@ def reconfigure_systemd_networkd(rootdir):
                             ignore = True
                             break
                     if not ignore:
-                        thispars = ConfigParser()
+                        systemtd_net_config = ConfigParser()
                         sys_data[sf] = dict()
                         try:
-                            sv = thispars.read(sf)
-                            if 'Match' in thispars.sections():
-                                ifname = thispars.get('Match', 'Name')
+                            sv = systemtd_net_config.read(sf)
+                            if 'Match' in systemtd_net_config.sections():
+                                ifname = systemtd_net_config.get('Match', 'Name')
                                 sys_nics.append(ifname)
                             else:
                                 _logger.debug('-- No Match section in %s' % sf)
                             #
-                            for sec in thispars.sections():
-                                sys_data[sf][sec] = thispars.items(sec)
+                            for sec in systemtd_net_config.sections():
+                                sys_data[sf][sec] = systemtd_net_config.items(sec)
                                 _logger.debug('%s' % sys_data[sf][sec])
                         except Exception as e:
                             _logger.error('Failed to parse %s: %s' % (sf, str(e)))
                         #
                         # rename - backup
                         bcknm = os.path.split(sf)[0] + '/bck_' \
-                                + os.path.split(sf)[1] + '_' \
-                                + migrate_tools.thistime
+                                              + os.path.split(sf)[1] + '_' \
+                                              + migrate_tools.current_time
                         if migrate_tools.exec_rename(sf, bcknm):
                             _logger.debug('Network config file %s renamed to %s'
                                           % (sf, bcknm))
                             _logger.debug('Network config file %s successfully '
-                                         'renamed to %s'
-                                         % (sf, os.path.split(sf)[0]
+                                          'renamed to %s'
+                                          % (sf, os.path.split(sf)[0]
                                             + '/bck' + os.path.split(sf)[1]
                                             + '_bck'))
                         else:
                             _logger.error('Failed to rename %s to %s'
-                                         % (sf, os.path.split(sf)[0]
+                                          % (sf, os.path.split(sf)[0]
                                             + '/bck'
                                             + os.path.split(sf)[1]
                                             + '_bck'))
@@ -493,7 +491,7 @@ def reconfigure_systemd_networkd(rootdir):
                 _logger.debug('No systemd-networkd configuration.')
         else:
             _logger.debug('%s does not exist.'
-                         % get_config_data('default_systemd'))
+                          % get_config_data('default_systemd'))
     #
     # write new config
     if len(sys_nics) > 0:
@@ -502,7 +500,7 @@ def reconfigure_systemd_networkd(rootdir):
             sdf.writelines(ln.replace('_XXXX_', nicname) + '\n'
                            for ln in get_config_data('default_systemd_config'))
         migrate_tools.result_msg(msg='systemd-networkd configuration rewritten.',
-                             result=True)
+                                 result=True)
     else:
         _logger.debug('No systemd-networkd configuration.')
     return sorted(sys_nics), sys_data

--- a/lib/oci_utils/migrate/some_img_type.py
+++ b/lib/oci_utils/migrate/some_img_type.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 
@@ -76,7 +76,7 @@ class SomeTypeHead(DeviceData):
                 _logger.debug('%s header successfully read' % self._fn)
         except Exception as e:
             _logger.critical('Failed to read header of %s: %s'
-                                  % (self._fn, str(e)))
+                             % (self._fn, str(e)))
             raise OciMigrateException('Failed to read the header of %s: %s'
                                       % (self._fn, str(e)))
 
@@ -96,7 +96,7 @@ class SomeTypeHead(DeviceData):
             self.devicename = self.mount_img()
             _logger.debug('Image data %s' % self.devicename)
             migrate_tools.result_msg(msg='Mounted %s' % self.devicename,
-                                 result=True)
+                                     result=True)
             deviceinfo = self.handle_image()
         except Exception as e:
             _logger.critical('error %s' % str(e))

--- a/lib/oci_utils/migrate/some_img_type.py
+++ b/lib/oci_utils/migrate/some_img_type.py
@@ -1,0 +1,158 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module to handle sometype formatted virtual disk images, intended as a template.
+"""
+import logging
+import os
+import struct
+
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.imgdevice import DeviceData
+from oci_utils.migrate.migrate_utils import OciMigrateException
+
+"""  
+typedef struct SometypeHeader {
+      uint32_t magic;
+      uint32_t version;
+      ...
+  } SometypeHeader;
+"""
+
+format_data = {'01234567': {'name': 'sometype',
+                            'module': 'sometype',
+                            'clazz': 'SomeTypeHead',
+                            'prereq': {'MAX_IMG_SIZE_GB': 300.0}}}
+
+_logger = logging.getLogger('oci-utils.some-img-type')
+
+
+class SomeTypeHead(DeviceData):
+    """
+    Class to analyse header of sometype image file; ref whatever..
+
+    Attributes
+    ----------
+        filename: str
+            The full path of the vmdk image file.
+        stat: tuple
+            The image file stat data.
+        img_tag: str
+            The bare file name.
+        somehead_dict: dict
+            The SomeType file header as a dictionary.
+    """
+    # sometype header definition:
+    uint32_t = 'I'  # 32bit unsigned int
+    uint64_t = 'Q'  # 64bit unsigned long
+    header2_structure = [[uint32_t, '%#x', 'magic'],
+                         [uint32_t, '%d', 'version'],
+
+                         ]
+
+    # struct format string
+    sometypehead_fmt = '>' + ''.join(f[0] for f in header2_structure)
+    head_size = struct.calcsize(sometypehead_fmt)
+
+    def __init__(self, filename):
+        """
+        Initialisation of the sometype header analysis.
+
+        Parameters
+        ----------
+        filename: str
+            Full path of the qcow2 image file.
+        """
+        super(SomeTypeHead, self).__init__(filename)
+        _logger.debug('sometype header size: %d bytes' % self.head_size)
+
+        try:
+            with open(self._fn, 'rb') as f:
+                head_bin = f.read(self.head_size)
+                _logger.debug('%s header successfully read' % self._fn)
+        except Exception as e:
+            _logger.critical('Failed to read header of %s: %s'
+                                  % (self._fn, str(e)))
+            raise OciMigrateException('Failed to read the header of %s: %s'
+                                      % (self._fn, str(e)))
+
+        sometypeheader = struct.unpack(SomeTypeHead.sometypehead_fmt, head_bin)
+
+        self.stat = os.stat(self._fn)
+        self.img_tag = os.path.splitext(os.path.split(self._fn)[1])[0]
+        self.somehead_dict = dict((name[2], sometypeheader[i])
+                                  for i, name
+                                  in enumerate(SomeTypeHead.header2_structure))
+        self.img_header = dict()
+        self.img_header['head'] = self.somehead_dict
+        migrate_tools.result_msg(msg='Got image %s header' % filename, result=True)
+        #
+        # mount the image using the nbd
+        try:
+            self.devicename = self.mount_img()
+            _logger.debug('Image data %s' % self.devicename)
+            migrate_tools.result_msg(msg='Mounted %s' % self.devicename,
+                                 result=True)
+            deviceinfo = self.handle_image()
+        except Exception as e:
+            _logger.critical('error %s' % str(e))
+            raise OciMigrateException(str(e))
+
+    def show_header(self):
+        """
+        Lists the header contents formatted.
+
+        Returns
+        -------
+            No return value.
+        """
+        pass
+
+    def image_size(self):
+        """
+        Get the size of the image file.
+
+        Returns
+        -------
+            tuple: (float, float)
+                physical file size, logical file size
+        """
+        pass
+
+    def image_supported(self, image_defs):
+        """
+        Verifies if the image file is supported for migration to the Oracle
+        cloud infrastructure.
+
+        Returns
+        -------
+            bool: True on success, False otherwise.
+            str:  Eventual message on success or failure.
+        """
+        pass
+
+    def image_data(self):
+        """
+        Collect data about contents of the image file.
+
+        Returns
+        -------
+            bool: True on success, False otherwise;
+            dict: The image data.
+        """
+        pass
+
+    def type_specific_prereq_test(self):
+        """
+        Verify the prerequisites specific for the image type.
+
+        Returns
+        -------
+            bool: True or False.
+            str : Message
+        """
+        pass

--- a/lib/oci_utils/migrate/some_type_os.py
+++ b/lib/oci_utils/migrate/some_type_os.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 

--- a/lib/oci_utils/migrate/some_type_os.py
+++ b/lib/oci_utils/migrate/some_type_os.py
@@ -1,0 +1,43 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module containing Some Linux type specific OS methods; intended as a
+template.
+"""
+import logging
+
+from oci_utils.migrate import console_msg
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.exception import OciMigrateException
+
+_logger = logging.getLogger('oci-utils.some-type-os')
+
+_os_type_tag_csl_tag_type_os_ = 'sometype,'
+
+
+def os_banner():
+    """
+    Show OS banner.
+    Returns
+    -------
+        No return value.
+    """
+    console_msg('OS is one of %s' % _os_type_tag_csl_tag_type_os_)
+
+
+def install_cloud_init(*args):
+    """
+    Install cloud init package
+    Parameters
+    ----------
+    args: tbd
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    pass

--- a/lib/oci_utils/migrate/tests/test_migrate_tools.py
+++ b/lib/oci_utils/migrate/tests/test_migrate_tools.py
@@ -1,0 +1,163 @@
+import shutil
+import os
+import tempfile
+import unittest
+try:
+    import unittest.mock as mock
+    from unittest.mock import Mock
+except ImportError:
+    import mock
+    from mock import Mock
+
+from oci_utils.migrate import migrate_tools as migrate_tools
+from oci_utils.migrate.exception import NoSuchCommand
+
+def my_fake_open(path, mode):
+    fake_file = tempfile.NamedTemporaryFile()
+    fake_file_name = fake_file.name
+    return open(fake_file_name, mode)
+
+
+class TestMigrateTools(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_is_root(self):
+        os.getuid = Mock()
+        os.getuid.side_effect = [0, 100]
+        self.assertTrue(migrate_tools.is_root())
+        self.assertFalse(migrate_tools.is_root())
+
+    def test_get_magic_data(self):
+        fakeimage = tempfile.NamedTemporaryFile()
+        fakeimagename = fakeimage.name
+        fakeimagemagic = b'\x4b\x44\x4d\x56 ... more ... data ...'
+        with open(fakeimagename, 'wb') as f:
+            f.write(fakeimagemagic)
+        self.assertEqual(migrate_tools.get_magic_data(fakeimagename), '4b444d56')
+
+    def test_get_magic_data_fail(self):
+        self.assertIsNone(migrate_tools.get_magic_data('notexistingimage'))
+
+    def test_exec_exists(self):
+        self.assertTrue(migrate_tools.exec_exists('uname'))
+        self.assertFalse(migrate_tools.exec_exists('some_very_weird_exec_name'))
+
+    @mock.patch('oci_utils.migrate.migrate_tools.os.path')
+    @mock.patch('oci_utils.migrate.migrate_tools.os')
+    def test_exec_rename(self, patched_os, patched_os_path):
+        fromname = mock.Mock()
+        toname = mock.Mock()
+        # to does not exist, from does not exist,
+        # to is not a link, from is not a link
+        # error message, return False
+        print('exec_rename test 01')
+        patched_os_path.exists.return_value = False
+        patched_os_path.islink.return_value = False
+        self.assertFalse(migrate_tools.exec_rename(fromname, toname))
+        # to does not exists, from does exist
+        # to is not a link, from is not a link
+        # return True
+        print('exec_rename test 02')
+        patched_os_path.exists.side_effect = [False, True]
+        patched_os_path.islink.side_effect = [False, False]
+        tstrename = migrate_tools.exec_rename(fromname, toname)
+        self.assertTrue(tstrename)
+        patched_os.rename.assert_called_with(fromname, toname)
+        # to does exists and is a file, from does not exist
+        # to is not a link, from is not a link
+        # return False
+        print('exec_rename test 03')
+        patched_os_path.isfile.return_value = True
+        patched_os_path.exists.side_effect = [True, False]
+        patched_os_path.islink.side_effect = [False, False]
+        tstrename = migrate_tools.exec_rename(fromname, toname)
+        self.assertFalse(tstrename)
+        patched_os.remove.assert_called_with(toname)
+        # to does exists and is a file, from does exist and is a file
+        # to is not a link, from is not a link
+        # return True
+        print('exec_rename test 04')
+        patched_os_path.isfile.return_value = True
+        patched_os_path.exists.side_effect = [True, True]
+        patched_os_path.islink.side_effect = [False, False]
+        tstrename = migrate_tools.exec_rename(fromname, toname)
+        self.assertTrue(tstrename)
+        patched_os.remove.assert_called_with(toname)
+        # to does exists and is a dir, from does not exist
+        # to is not a link, from is not a link
+        # return True
+        print('exec_rename test 05')
+        patched_os_path.isfile.return_value = False
+        patched_os_path.isdir.return_value = True
+        patched_os_path.exists.side_effect = [True, True]
+        patched_os_path.islink.side_effect = [False, False]
+        tstrename = migrate_tools.exec_rename(fromname, toname)
+        self.assertTrue(tstrename)
+        patched_os.rmdir.assert_called_with(toname)
+        # to does exists and is a symbolic link, from does not exist
+        # to is not a link, from is not a link
+        # return True
+        print('exec_rename test 06')
+        patched_os_path.isfile.return_value = False
+        patched_os_path.isdir.return_value = False
+        patched_os_path.unlink.return_value = True
+        patched_os_path.exists.side_effect = [True, True]
+        patched_os_path.islink.side_effect = [True, False]
+        tstrename = migrate_tools.exec_rename(fromname, toname)
+        self.assertTrue(tstrename)
+        patched_os.unlink.assert_called_with(toname)
+        #
+        # not all combinations are tested here, but except the exception raise,
+        # all individual lines of code are used.
+
+    @mock.patch('oci_utils.migrate.migrate_tools')
+    def test_run_popen_cmd(self, patched_migrate_tools):
+        #
+        # existing
+        somecommand = ['echo', 'test']
+        patched_migrate_tools.exec_exists.return_value = True
+        popenreturnval = migrate_tools.run_popen_cmd(somecommand)
+        self.assertEqual(popenreturnval, 'test\n')
+        #
+        # not existing
+        somecommand = ['noecho', 'test']
+        self.assertRaises(NoSuchCommand, migrate_tools.run_popen_cmd, somecommand)
+
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_get_nameserver(self, patched_popen):
+        patched_popen.return_value = 'no name server in here'
+        self.assertFalse(migrate_tools.get_nameserver())
+        patched_popen.return_value = \
+'IP4.ROUTE[2]:                           dst = 169.254.0.0/16, nh = 0.0.0.0, mt = 1000\n' \
+'IP4.ROUTE[3]:                           dst = 0.0.0.0/0, nh = 10.172.216.1, mt = 100\n' \
+'IP4.DNS[1]:                             10.254.231.168\n' \
+'IP6.ADDRESS[1]:                         2606:b400:808:44:5b20:2dcd:b2f0:298f/64\n' \
+'IP6.ADDRESS[2]:                         fe80::b8e4:4f25:6de5:3f0c/64'
+        self.assertTrue(migrate_tools.get_nameserver())
+
+    @mock.patch('oci_utils.migrate.migrate_tools.os.path')
+    @mock.patch('oci_utils.migrate.migrate_tools.open', my_fake_open)
+    def test_set_nameserver(self, patched_os_path):
+        #
+        # rename tested elsewhere, skip
+        patched_os_path.isfile.return_value = False
+        patched_os_path.isdir.return_value = False
+        patched_os_path.islink.return_value = False
+        #
+        # destination exists
+        patched_os_path.exists = True
+        nssetreturn = migrate_tools.set_nameserver()
+        self.assertTrue(nssetreturn)
+
+    def test_restore_nameserver(self):
+        #
+        #  rename files tested elsewhere
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/oci_utils/migrate/tests/test_migrate_utils.py
+++ b/lib/oci_utils/migrate/tests/test_migrate_utils.py
@@ -1,0 +1,300 @@
+import shutil
+import os
+import tempfile
+import unittest
+try:
+    import unittest.mock as mock
+    from unittest.mock import Mock
+except ImportError:
+    import mock
+    from mock import Mock
+
+from oci_utils.migrate import migrate_tools as migrate_tools
+from oci_utils.migrate import migrate_utils as migrate_utils
+from oci_utils.migrate.exception import NoSuchCommand
+from oci_utils.migrate.exception import OciMigrateException
+
+def my_fake_open(path, mode):
+    print ('fake open')
+    return open('fake_file_path', mode)
+
+def my_fake_call(somecall):
+    print ('fake call')
+    return False
+
+class TestMigrateUtils(unittest.TestCase):
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_bucket_exists(self, patched_popen):
+        #
+        # oci cli exists, buckect exists
+        patched_popen.side_effect = ['oci_cli_path', 'bucket_result']
+        self.assertTrue(migrate_utils.bucket_exists('fake_bucket'))
+        patched_popen.assert_called_with(['oci', 'os', 'object', 'list', '--bucket-name', 'fake_bucket'])
+        #
+        # oci cli exists, bucket does not exists
+        patched_popen.side_effect = ['oci_cli_path' ]
+        self.assertRaises(OciMigrateException, migrate_utils.bucket_exists, 'fake_bucket')
+        patched_popen.assert_called_with(['oci', 'os', 'object', 'list', '--bucket-name', 'fake_bucket'])
+        #
+        # oci cli does not exist (not redefining the popen side effect causes popen excepts out)
+        self.assertRaises(OciMigrateException, migrate_utils.bucket_exists, 'fake_bucket')
+        patched_popen.assert_called_with(['oci', 'os', 'object', 'list', '--bucket-name', 'fake_bucket'])
+
+    @mock.patch('oci_utils.migrate.migrate_utils.run_call_cmd')
+    def test_create_nbd(self, patched_call):
+        patched_call.side_effect = [0, 1]
+        self.assertTrue(migrate_utils.create_nbd())
+        patched_call.assert_called_with(['modprobe', 'nbd', 'max_part=63'])
+        self.assertFalse(migrate_utils.create_nbd())
+        patched_call.assert_called_with(['modprobe', 'nbd', 'max_part=63'])
+
+    @mock.patch.dict('oci_utils.migrate.migrate_utils.os.environ', {'PATH': '/usr/local/bin:/usr/bin:/bin'}, clear=True)
+    @mock.patch('oci_utils.migrate.migrate_utils.os')
+    def test_enter_chroot(self, patched_os):
+        patched_os.open.return_value = '/someroot'
+        oldroot, oldpath = migrate_utils.enter_chroot('self.tempdir')
+        # ignore oldpath, not used
+        self.assertEqual(oldroot,  '/someroot')
+        #
+        # os.open throws an exception
+        with mock.patch('oci_utils.migrate.migrate_utils.os.open') as mock_oserror:
+            mock_oserror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.enter_chroot, 'self.tempdir')
+        #
+        # 
+        # with mock.patch('oci_utils.migrate.migrate_utils.os.environ') as mock_keyerror:
+        #    mock_keyerror.side_effect = KeyError
+        #    self.assertRaises(OciMigrateException, migrate_utils.enter_chroot, 'self.tempdir')
+
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_blkid(self, patched_popen):
+        blkidres = ['ID_FS_USAGE=raid', 'ID_PART_ENTRY_SCHEME=dos', 'ID_MORE=xyz']
+        patched_popen.return_value = blkidres
+        self.assertEqual(migrate_utils.exec_blkid(['some', 'blkid', 'cmd']), blkidres)
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertIsNone(migrate_utils.exec_blkid(['some', 'blkid', 'cmd']))
+    
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_lsblk(self, patched_popen):
+        patched_popen.return_value = 0
+        self.assertEqual(migrate_utils.exec_lsblk(['some', 'lsblk', 'cmd']), 0)
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_lsblk, ['some', 'blkid', 'cmd'])
+    
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_lvscan(self, patched_popen):
+        patched_popen.return_value = "  inactive            '/dev/ol_tstoci-001/swap' [2.00 GiB] inherit\n  inactive            '/dev/ol_tstoci-001/root' [20.99 GiB] inherit\n"
+        self.assertEqual(migrate_utils.exec_lvscan(),{'ol_tstoci-001': [('swap', 'ol_tstoci--001-swap'), ('root', 'ol_tstoci--001-root')]})
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_lvscan)
+    
+    @mock.patch('oci_utils.migrate.migrate_tools.os.path.exists')
+    @mock.patch('oci_utils.migrate.migrate_tools.os.makedirs')  
+    def test_exec_mkdir(self, patched_os_makedirs, patched_os_exists):
+        dirname = mock.Mock()
+        patched_os_exists.side_effect = [False, True]
+        #
+        # does not exist
+        migrate_utils.exec_mkdir(dirname)
+        patched_os_exists.assert_called_with(dirname)
+        patched_os_makedirs.assert_called_with(dirname)
+        #
+        # already exists
+        migrate_utils.exec_mkdir(dirname)
+        patched_os_exists.assert_called_with(dirname)
+        #
+        # os.makedirs raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.os.makedirs') as mock_mkdirerror:
+            mock_mkdirerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_mkdir, dirname)
+    
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_parted(self, patched_popen):
+        patched_popen.return_value = '^[[?1034hModel: Unknown (unknown)\n' \
+            'Disk /dev/nbd3: 25.8GB\n' \
+            'Sector size (logical/physical): 512B/512B\n' \
+            'Partition Table: msdos\n' \
+            'Disk Flags:\n' \
+            'Number  Start   End     Size    Type     File system  Flags\n' \
+            ' 1      1049kB  1075MB  1074MB  primary  xfs          boot\n' \
+            ' 2      1075MB  25.8GB  24.7GB  primary               lvm'
+        parted_return_value = {'Model': ' Unknown (unknown)', 'Disk': '', 'Partition Table': ' msdos'}
+        self.assertEqual(migrate_utils.exec_parted('xyz'), parted_return_value)
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertIsNone(migrate_utils.exec_parted('xyz'))
+
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_pvscan(self, patched_popen):
+        patched_popen.return_value = 'the physical volumes'
+        self.assertTrue('oci_utils.exec_pvscan()')
+        devname = '/device/name'
+        self.assertTrue('oci_utils.exec_pvscan(devname)')
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_pvscan, 'xyz')
+    
+    @mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd')
+    def test_exec_qemunbd(self, patched_popen):
+        patched_popen.return_value = 0
+        self.assertEqual(migrate_utils.exec_qemunbd([ '-c','/dev/nbd_x','/image/path']), 0)
+        #
+        # run_popen_cmd raises an exception
+        with mock.patch('oci_utils.migrate.migrate_tools.run_popen_cmd') as mock_popenerror:
+            mock_popenerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_qemunbd, ['xyz'])
+    
+    @mock.patch('oci_utils.migrate.migrate_utils.shutil')
+    def test_exec_rmdir(self, patched_shutil):
+        dirname = mock.Mock()
+        migrate_utils.exec_rmdir(dirname)
+        patched_shutil.rmtree.assert_called_with(dirname)
+        #
+        # rmtree raises an exception
+        with mock.patch('oci_utils.migrate.migrate_utils.shutil.rmtree') as mock_rmtreeerror:
+            mock_rmtreeerror.side_effect = OSError
+            self.assertRaises(OciMigrateException, migrate_utils.exec_rmdir, dirname)
+
+    @mock.patch('oci_utils.migrate.migrate_utils.subprocess')
+    def test_exec_rmmod(self, patched_subprocess):
+        patched_subprocess.side_effect = [0, 1]
+        self.assertTrue(migrate_utils.exec_rmmod('module'))
+        self.assertTrue(migrate_utils.exec_rmmod('module'))
+        #
+        # check_call raises an exception
+        with mock.patch('oci_utils.migrate.migrate_utils.subprocess.check_call') as mock_checkcallerror:
+            mock_checkcallerror.side_effect = OSError
+            self.assertTrue(migrate_utils.exec_rmmod('module'))
+
+    @mock.patch('oci_utils.migrate.migrate_utils.os')
+    def test_exec_search(self, patched_os):
+        patched_os.walk.return_value = [('/a',('b',), ('1',)),
+                                        ('/a/1',(),('c','2','3'))]
+        self.assertEqual(str(migrate_utils.exec_search('c')), 'a/b/c')
+       
+    
+    def exec_sfdisk(self):
+        pass
+    
+    def exec_vgchange(self):
+        pass
+    
+    def exec_vgscan(self):
+        pass
+    
+    def find_os_specific(self):
+        pass
+    
+    def get_free_nbd(self):
+        pass
+    
+    def get_nameserver(self):
+        pass
+    
+    def get_oci_config(self):
+        pass
+    
+    def leave_chroot(self):
+        pass
+    
+    def mount_fs(self):
+        pass
+    
+    def mount_imgfn(self):
+        pass
+    
+    def mount_lvm2(self):
+        pass
+    
+    def mount_partition(self):
+        pass
+    
+    def mount_pseudo(self):
+        pass
+    
+    def object_exists(self):
+        pass
+    
+    def print_header(self):
+        pass
+    
+    def rm_nbd(self):
+        pass
+    
+    def set_default_user(self):
+        pass
+    
+    def show_fstab(self):
+        pass
+    
+    def show_grub_data(self):
+        pass
+    
+    def show_hex_dump(self):
+        pass
+    
+    def show_image_data(self):
+        pass
+    
+    def show_img_header(self):
+        pass
+    
+    def show_lvm2_data(self):
+        pass
+    
+    def show_network_data(self):
+        pass
+    
+    def show_parted_data(self):
+        pass
+    
+    def show_partition_data(self):
+        pass
+    
+    def show_partition_table(self):
+        pass
+    
+    def state_loop(self):
+        pass
+    
+    def unmount_imgfn(self):
+        pass
+    
+    def unmount_lvm2(self):
+        pass
+    
+    def unmount_part(self):
+        pass
+    
+    def unmount_pseudo(self):
+        pass
+    
+    def unmount_something(self):
+        pass
+    
+    def upload_image(self):
+        pass
+    
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/lib/oci_utils/migrate/ubuntu_type_os.py
+++ b/lib/oci_utils/migrate/ubuntu_type_os.py
@@ -1,6 +1,6 @@
 # oci-utils
 #
-# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown
 # at http://oss.oracle.com/licenses/upl.
 
@@ -44,7 +44,7 @@ def exec_apt(cmd):
     _logger.debug('apt command: %s' % cmd)
     try:
         _logger.debug('command: %s' % cmd)
-        output = migrate_tools.run_popen_cmd(cmd)
+        output = migrate_tools.run_popen_cmd(cmd).decode('utf-8')
         _logger.debug('apt command output: %s' % str(output))
         return output
     except Exception as e:

--- a/lib/oci_utils/migrate/ubuntu_type_os.py
+++ b/lib/oci_utils/migrate/ubuntu_type_os.py
@@ -1,0 +1,100 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+""" Module containing Ubuntu Linux type specific OS methods.
+"""
+import logging
+
+from oci_utils.migrate import console_msg, pause_msg
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.exception import OciMigrateException
+
+_logger = logging.getLogger('oci-utils.ubuntu-type-os')
+
+_os_type_tag_csl_tag_type_os_ = 'ubuntu, debian,'
+
+
+def os_banner():
+    """
+    Show OS banner.
+    Returns
+    -------
+        No return value.
+    """
+    console_msg('OS is one of %s' % _os_type_tag_csl_tag_type_os_)
+
+
+def exec_apt(cmd):
+    """
+    Execute an apt command.
+
+    Parameters
+    ----------
+    cmd: list
+        The apt command as a list.
+
+    Returns
+    -------
+        str: apt output on success, raises an exception otherwise.
+    """
+    cmd = ['/usr/bin/apt'] + cmd
+    _logger.debug('apt command: %s' % cmd)
+    try:
+        _logger.debug('command: %s' % cmd)
+        output = migrate_tools.run_popen_cmd(cmd)
+        _logger.debug('apt command output: %s' % str(output))
+        return output
+    except Exception as e:
+        _logger.critical('Failed to execute apt: %s' % str(e))
+        raise OciMigrateException('\nFailed to execute apt: %s' % str(e))
+
+
+def install_cloud_init(*args):
+    """
+    Install cloud init package
+    Parameters
+    ----------
+    args: tbd
+
+    Returns
+    -------
+        bool: True on success, False otherwise.
+    """
+    try:
+        if migrate_tools.set_nameserver():
+            _logger.debug('Updating nameserver info succeeded.')
+        else:
+            _logger.error('Failed to update nameserver info.')
+        #
+        deblist = exec_apt(['list', 'cloud-init'])
+        cloud_init_present = False
+        for pkg in deblist.splitlines():
+            _logger.debug('%s' % pkg)
+            if 'cloud-init' in pkg:
+                _logger.debug('The deb package cloud-init is available.')
+                cloud_init_present = True
+                break
+        if not cloud_init_present:
+            _logger.debug('The deb package cloud-init is missing.')
+            migrate_tools.migrate_preparation = False
+            migrate_tools.migrate_non_upload_reason += \
+                '\n  The deb package cloud-init is missing from the repository.'
+            return False
+        else:
+            installoutput = exec_apt(['install', '-y', 'cloud-init'])
+            _logger.debug('Successfully installed cloud init:\n%s' % installoutput)
+        pause_msg('Installed cloud-init here, or not.')
+        if migrate_tools.restore_nameserver():
+            _logger.debug('Restoring nameserver info succeeded.')
+        else:
+            _logger.error('Failed to restore nameserver info.')
+    except Exception as e:
+        _logger.critical('Failed to install the cloud-init package:\n%s' % str(e))
+        migrate_tools.error_msg('Failed to install the cloud-init package:\n%s' % str(e))
+        migrate_tools.migrate_non_upload_reason += \
+            '\n Failed to install the cloud-init package: %s' % str(e)
+        return False
+    return True

--- a/lib/oci_utils/migrate/vmdk.py
+++ b/lib/oci_utils/migrate/vmdk.py
@@ -1,0 +1,304 @@
+# oci-utils
+#
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Module to handle VMDK formatted virtual disk images.
+"""
+import logging
+import os
+import re
+import struct
+
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate.imgdevice import DeviceData
+from oci_utils.migrate.migrate_utils import gigabyte as gigabyte
+from oci_utils.migrate.migrate_utils import OciMigrateException
+
+"""
+typedef uint64 SectorType;
+typedef uint8 Bool;
+typedef struct SparseExtentHeader {
+    uint32       magicNumber;
+    uint32       version;
+    uint32       flags;
+    SectorType   capacity;
+    SectorType   grainSize;
+    SectorType   descriptorOffset;
+    SectorType   descriptorSize;
+    uint32       numGTEsPerGT;
+    SectorType   rgdOffset;
+    SectorType   gdOffset;
+    SectorType   overHead;
+    Bool         uncleanShutdown;
+    char         singleEndLineChar;
+    char         nonEndLineChar;
+    char         doubleEndLineChar1;
+    char         doubleEndLineChar2;
+    uint16       compressAlgorithm;
+    uint8        pad[433];
+} SparseExtentHeader
+"""
+
+format_data = {'4b444d56': {'name': 'vmdk',
+                            'module': 'vmdk',
+                            'clazz': 'VmdkHead',
+                            'prereq': {'MAX_IMG_SIZE_GB': 300.0,
+                                       'vmdk_supported_types':
+                                           ['monolithicSparse',
+                                            'streamOptimized']}}}
+
+_logger = logging.getLogger('oci-utils.vmdk')
+
+
+class VmdkHead(DeviceData):
+    """
+    Class to analyse header of vmdk image file.
+
+    Attributes
+    ----------
+        filename: str
+            The full path of the vmdk image file.
+        stat: tuple
+            The image file stat data.
+        img_tag: str
+            The bare file name.
+        vmdkhead_dict: dict
+            The VMDK file header as a dictionary.
+        vmdkdesc_dict: dict
+            The VMDK file description as a dictionary.
+    """
+    #
+    Bool = '?'
+    char = 'B'        # 1 byte char
+    uint8 = 'B'       # 1 byte unsigned int
+    uint16 = 'H'      # 16bit unsigned int
+    uint32 = 'I'      # 32bit unsigned int
+    uint64 = 'Q'      # 64bit unsigned long
+    SectorType = 'Q'  # 64bit unsigned long
+    string = 's'      # string
+    #
+    # vmdk header0 definition:
+    header0_structure = [[uint32,     '%#x', 'magic'],
+                         [uint32,     '%d',  'version'],
+                         [uint32,     '%#x', 'flags'],
+                         [SectorType, '%d',  'capacity'],
+                         [SectorType, '%d',  'grainSize'],
+                         [SectorType, '%d',  'descriptorOffset'],
+                         [SectorType, '%d',  'descriptorSize'],
+                         [uint32,     '%d',  'numGTEsPerGT'],
+                         [SectorType, '%d',  'rgdOffset'],
+                         [SectorType, '%d',  'gdOffset'],
+                         [SectorType, '%d',  'overHead'],
+                         [Bool,       '%#x', 'uncleanShutdown'],
+                         [char,       '%#x', 'singleEndLineChar'],
+                         [char,       '%#x', 'nonEndLineChar'],
+                         [char,       '%#x', 'doubleEndLineChar1'],
+                         [char,       '%#x', 'doubleEndLineChar2'],
+                         [uint16,     '%s',  'compressAlgorithm'],
+                         [uint8,      '%#x', 'pad'] * 433]
+    #
+    # struct format string
+    vmdkhead_fmt = '<' + ''.join(f[0] for f in header0_structure)
+    head_size = struct.calcsize(vmdkhead_fmt)
+    _logger = logging.getLogger('oci-utils.vmdk')
+
+    def __init__(self, filename):
+        """
+        Initialisation of the vmdk header analysis.
+
+        Parameters
+        ----------
+        filename: str
+            Full path of the qcow2 image file.
+        logger: loggername
+            The logging specification.
+        """
+        super(VmdkHead, self).__init__(filename)
+        _logger.debug('VMDK header size: %d bytes' % self.head_size)
+
+        try:
+            with open(self._fn, 'rb') as f:
+                head_bin = f.read(self.head_size)
+                _logger.debug('%s header successfully read' % self._fn)
+        except Exception as e:
+            _logger.critical(
+                'Failed to read header of %s: %s' % (self._fn, str(e)))
+            raise OciMigrateException(
+                'Failed to read the header of %s: %s' % (self._fn, str(e)))
+
+        vmdkheader = struct.unpack(VmdkHead.vmdkhead_fmt, head_bin)
+
+        try:
+            with open(self._fn, 'rb') as f:
+                f.seek(512)
+                head_descr = [it for it in f.read(1024).splitlines() if
+                              '=' in it]
+        except Exception as e:
+            _logger.critical(
+                'Failed to read description of %s: %s' % (self._fn, str(e)))
+            raise OciMigrateException(
+                'Failed to read the description  of %s: %s' % (self._fn, str(e)))
+
+        self.stat = os.stat(self._fn)
+        self.img_tag = os.path.splitext(os.path.split(self._fn)[1])[0]
+        self.vmdkhead_dict = dict((name[2], vmdkheader[i]) for i, name in
+                                  enumerate(VmdkHead.header0_structure))
+        self.vmdkdesc_dict = dict(
+            [re.sub(r'"', '', kv).split('=') for kv in head_descr])
+        self.img_header = dict()
+        self.img_header['head'] = self.vmdkhead_dict
+        self.img_header['desc'] = self.vmdkdesc_dict
+        migrate_tools.result_msg(msg='Got image %s header' % filename, result=True)
+
+    def show_header(self):
+        """
+        Lists the header contents formatted.
+
+        Returns
+        -------
+            No return value.
+        """
+        migrate_tools.result_msg(msg='\n  %30s\n  %30s   %30s'
+                                 % ('VMDK file header data', '-' * 30, '-' * 30),
+                             result=False)
+        for f in VmdkHead.header0_structure:
+            migrate_tools.result_msg(msg=''.join(['  %30s : ' % f[2], f[1]
+                                              % self.vmdkhead_dict[f[2]]]),
+                                 result=False)
+        migrate_tools.result_msg(msg='\n  %30s\n  %30s   %30s'
+                                 % ('VMDK file descriptor data',
+                                    '-' * 30, '-' * 30),
+                             result=False)
+        for k in sorted(self.vmdkdesc_dict):
+            migrate_tools.result_msg(msg='  %30s : %-30s'
+                                     % (k, self.vmdkdesc_dict[k]), result=False)
+
+    def image_size(self):
+        """
+        Get the size of the image file.
+
+        Returns
+        -------
+            dict:
+                physical file size, logical file size
+        """
+        img_sz = {'physical': float(self.stat.st_size)/gigabyte,
+                  'logical': float(self.vmdkhead_dict['capacity']*512)/gigabyte}
+
+        migrate_tools.result_msg(msg='Image size: physical %10.2f GB, '
+                                 'logical %10.2f GB'
+                                 % (img_sz['physical'], img_sz['logical']),
+                             result=True)
+        return img_sz
+
+    def image_supported(self, image_defs):
+        """
+        Verifies if the image file is supported for migration to the Oracle
+        cloud infrastructure.
+
+        Parameters
+        ----------
+            image_defs: dict
+                The predefined data and prerequisits for this type of image.
+        Returns
+        -------
+            bool: True on success, False otherwise.
+            str:  Eventual message on success or failure.
+        """
+        supp = True
+        prerequisites = image_defs['prereq']
+        msg = ''
+        if self.vmdkdesc_dict['createType'] \
+                in prerequisites['vmdk_supported_types']:
+            msg += 'Type is %s, OK.\n' % self.vmdkdesc_dict['createType']
+        else:
+            msg += 'Type %s is not supported.\n' % \
+                   self.vmdkdesc_dict['createType']
+            supp = False
+        sizes = self.image_size()
+        if sizes['logical'] > prerequisites['MAX_IMG_SIZE_GB']:
+            msg += 'Size of the image %.2f GB exceeds the maximum allowed ' \
+                   'size of %.2f GB.\n' % \
+                   (sizes['logical'], prerequisites['MAX_IMG_SIZE_GB'])
+            supp = False
+        else:
+            msg += 'Image size of %.2f GB below maximum allowed size ' \
+                   'of %.2f GB, OK.\n' % \
+                   (sizes['logical'], prerequisites['MAX_IMG_SIZE_GB'])
+        return supp, msg
+
+    def image_data(self):
+        """
+        Collect data about contents of the image file.
+
+        Returns
+        -------
+            bool: True on success, False otherwise;
+            dict: The image data.
+        """
+        _logger.debug('Image data: %s' % self._fn)
+        #
+        # initialise the dictionary for the image data
+        self._img_info['img_name'] = self._fn
+        self._img_info['img_type'] = 'VMDK'
+        self._img_info['img_header'] = self.img_header
+        self._img_info['img_size'] = self.image_size()
+
+        #
+        # mount the image using the nbd
+        try:
+            result = self.handle_image()
+        except Exception as e:
+            _logger.critical('error %s' % str(e))
+            raise OciMigrateException(str(e))
+        return result, self._img_info
+
+    def type_specific_prereq_test(self):
+        """
+        Verify the prerequisites specific for the image type from the header.
+
+        Returns
+        -------
+            bool: True or False.
+            str : Message
+        """
+        prereqs = format_data['4b444d56']['prereq']
+        failmsg = ''
+        #
+        # size:
+        thispass = True
+        if self._img_info['img_size']['logical'] > prereqs['MAX_IMG_SIZE_GB']:
+            _logger.critical('Image size %8.2f GB exceeds maximum '
+                                  'allowed %8.2f GB' %
+                                  (prereqs['MAX_IMG_SIZE_GB'],
+                                   self._img_info['img_size']['logical']))
+            failmsg += '\n  Image size %8.2f GB exceeds maximum allowed ' \
+                       '%8.2f GB' % (prereqs['MAX_IMG_SIZE_GB'],
+                                     self._img_info['img_size']['logical'])
+            thispass = False
+        else:
+            failmsg += '\n  Image size %8.2f GB meets maximum allowed size ' \
+                       'of %8.2f GB' % (self._img_info['img_size']['logical'],
+                                        prereqs['MAX_IMG_SIZE_GB'])
+
+        #
+        # type:
+        if self.img_header['desc']['createType'] \
+                not in prereqs['vmdk_supported_types']:
+            _logger.critical(
+                'Image type %s is not in the supported type list: %s' %
+                (self.img_header['desc']['createType'],
+                 prereqs['vmdk_supported_types']))
+            failmsg += 'Image type %s is not in the supported type list: %s' %\
+                       (self.img_header['desc']['createType'],
+                        prereqs['vmdk_supported_types'])
+            thispass = False
+        else:
+            failmsg += '  Image type %s is in the supported type list: %s' \
+                       % (self.img_header['desc']['createType'],
+                          prereqs['vmdk_supported_types'])
+
+        return thispass, failmsg

--- a/man/man1/oci-image-migrate-import.1
+++ b/man/man1/oci-image-migrate-import.1
@@ -1,0 +1,98 @@
+.\" Process this file with
+.\" groff -man -Tascii oci-image-migrate.1
+.\"
+.\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+.\"
+
+.TH OCI-IMAGE-MIGRATE 1 "JAN 2020" Linux "User Manuals"
+.SH NAME
+oci-image-migrate-import \- assist the import of an image in the 
+.B object storage
+to the 
+.B custom images
+reospitory of the Oracle Cloud Infrastructure
+.SH SYNOPSIS
+.B oci-image-migrate-import  [-i|--image-name
+.I image name
+.B ] [-b|--bucket-name
+.I bucketname
+.B ] [-c|--compartment-name
+.I compartment name
+.B ] [-d|--display-name
+.I display name
+.B ] [-l|--launch-mode
+.I [PARAVIRTUALIZED|EMULATED|NATIVE]
+.B ] [-v|--verbose] [--help]
+
+.SH DESCRIPTION
+The
+.B oci-image-migrate-import
+utility imports an image file residing in an object storage into the custom 
+images repository of
+.B Oracle Cloud Infrastructure.
+.B oci-image-migrate-mograte
+verifies the existence of the object storage and of the image file in the 
+object storage. It also checks if and image with the same name already exists 
+in the custom images repository.
+
+.B oci-image-migrate-import
+must be run with root priviliges, either as user root or using
+.BR sudo(8)
+on an on-premise physical or virtual server.
+.B oci-image-migrate-import
+requires the
+.B oci-cli
+utility installed and configured.
+
+See
+.BR https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliinstall.htm
+or
+.BR https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/climanualinst.htm
+for more information.
+
+.SH OPTIONS
+.IP "-i|--image-name"
+The name of the images as present in the object storage. This option is mandatory.
+.IP "-b|--bucket-name"
+The name of the object storage or bucket in the
+.B Oracle Cloud Infrastructure
+where the imagefile is stored. This option is mandatory.
+.IP "-c|--compartment-name"
+The name of the destination compartment. This option is mandatory.
+.IP "-d|--display-name"
+The image name or the name of the image as it will be saved in the custom
+images repository in the
+.B Oracle Cloud Infrastructure.
+This argument is optional, the default is the image name.
+.IP "-l|--launch-mode"
+The mode an instance created form the custom image will be started. Possible
+modes are PARAVIRTUALIZED, EMULATED and NATIVE. The default is PARAVIRTUALIZED.
+.IP "-v|--verbose"
+Show more information about the import on the console.
+.IP "--help"
+Print a summary of the command line options.
+
+.SH DIAGNOSTICS
+Returns an exit status of 0 for success or 1 if an error occured.
+
+.SH EXAMPLES
+.PP
+.nf
+.RS
+oci-image-migrate-import --image-name ol77 -b uk_bucket_001 -c ImageDev -l EMULATED  --display-name ol77_emulated -v
+.RE
+.fi
+.PP
+Imports the image file ol77, if it exists in the object storage uk_bucket_001 into the custom images repository of
+.B Oracle Cloud Infrastructure
+as ol77_emulated on condition there is not yet and image with the same name present,
+and sets the launch mode to EMULATED o
+
+.SH SEE ALSO
+.BR oci-image-migrate(1)
+.BR ocid (8)
+.BR oci-metadata (1)
+
+
+.SH COPYRIGHT
+Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -1,0 +1,67 @@
+.\" Process this file with
+.\" groff -man -Tascii oci-image-migrate.1
+.\"
+.\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\"
+
+.TH OCI-IMAGE-MIGRATE 1 "JUNE 2019" Linux "User Manuals"
+.SH NAME
+oci-image-migrate \- migrate on premise vm to the Oracle Cloud Infrastructure
+.SH SYNOPSIS
+.B oci-image-migrate [-i
+.I inputimage
+.B ] [-b
+.I bucketname
+.B ] [-o
+.I outputimage
+.B ] [ --quiet] [--verbose] [--help]
+
+
+Utility to support preparation of on-premise legacy images for importing in
+the Oracle Cloud Infrastructure.
+
+.SH DESCRIPTION
+The
+.B oci-image-migrate
+utility prepares the on-premise legacy images for importing in the Oracle Cloud
+Infrastructure.
+.B oci-image-migrate verifies and validates the prerequisites for the import of
+the image, installs the cloud-init software package and disables the network
+interfaces except the primary one which will be set up as a dhcp client.
+.B oci-image-migrate
+uploads the image file to the specified block storage location with a new image
+name if specified.
+
+The prerequites validated are:
+.IP
+The image is set up for BIOS boot.
+
+The size of the image is less or equal to 300GByte.
+
+The image contains only 1 virtual disk.
+
+The virtual disk contains an MBR boot loader.
+
+The boot process does not require additional data volumes for a successful boot.
+
+The disk image is not encrypted.
+
+The image is of type VMDK or QCOW2.
+
+The boot loader uses LVM or UUID to identify the boot volume.
+
+The network configuration does not refer explictly to hardware addresses.
+
+.SH EXAMPLES
+oci-image-migrate -i /data/images/ol7.qcow2 -b thisobjectstorate -o ol7atoci -v
+
+.SH SEE ALSO
+.BR ocid (8) oci-metadata (1)
+
+.SH BUGS
+
+.SH AUTHOR
+Guido Tijskens (guido.tijskens@oracle.com)
+
+.SH COPYRIGHT
+Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -27,7 +27,7 @@ verifies and validates the prerequisites for the import of
 the image, installs the cloud-init software package and disables the network
 interfaces except the primary one which will be set up as a dhcp client.
 .B oci-image-migrate
-uploads the image file to the specified block storage location with a new image
+uploads the image file to the specified object storage location with a new image
 name if specified.
 
 .B oci-image-migrate

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -6,62 +6,90 @@
 
 .TH OCI-IMAGE-MIGRATE 1 "JUNE 2019" Linux "User Manuals"
 .SH NAME
-oci-image-migrate \- migrate on premise vm to the Oracle Cloud Infrastructure
+oci-image-migrate \- assist the migration of on premise virtual machines to the
+Oracle Cloud Infrastructure
 .SH SYNOPSIS
-.B oci-image-migrate [-i
+.B oci-image-migrate [-i|--input-image
 .I inputimage
-.B ] [-b
+.B ] [-b|--bucket
 .I bucketname
-.B ] [-o
+.B ] [-o|--output-image
 .I outputimage
-.B ] [ --quiet] [--verbose] [--help]
-
-
-Utility to support preparation of on-premise legacy images for importing in
-the Oracle Cloud Infrastructure.
+.B ] [-v|--verbose] [--help]
 
 .SH DESCRIPTION
 The
 .B oci-image-migrate
-utility prepares the on-premise legacy images for importing in the Oracle Cloud
-Infrastructure.
-.B oci-image-migrate verifies and validates the prerequisites for the import of
+utility prepares an on-premise legacy image for importing into the
+.B Oracle Cloud Infrastructure.
+.B oci-image-migrate
+verifies and validates the prerequisites for the import of
 the image, installs the cloud-init software package and disables the network
 interfaces except the primary one which will be set up as a dhcp client.
 .B oci-image-migrate
 uploads the image file to the specified block storage location with a new image
 name if specified.
 
-The prerequites validated are:
-.IP
-The image is set up for BIOS boot.
+.B oci-image-migrate
+must be run with root priviliges, either as user root or using
+.BR sudo(8)
+on an on-premise physical or virtual server.
+.B oci-image-migrate
+requires the
+.B oci-cli
+utility installed and configured.
 
-The size of the image is less or equal to 300GByte.
+See
+.BR https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliinstall.htm
+or
+.BR https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/climanualinst.htm
+for more information.
 
-The image contains only 1 virtual disk.
+.B oci-image-migrate
+supports the migration of qcow2 and vmdk single file images.
 
-The virtual disk contains an MBR boot loader.
+.SH OPTIONS
+.IP "-i|--input-image"
+The full path name of the on-premise custom image. This option is mandatory.
+.IP "-b|--bucket"
+The name of the object storage or bucket in the
+.B Oracle Cloud Infrastructure,
+ the destination of the modified image file. This options is mandatory.
+.IP "-o|--output-image"
+The oci-image-name or the name of the image as it will be saved in the object
+storage in
+.B Oracle Cloud Infrastructure.
+This argument is optional, the default is the on-premise image name.
 
-The boot process does not require additional data volumes for a successful boot.
+.IP "-v|--verbose"
+Show information about the image file on the console. This information is also
+written to a result file in /var/tmp.
 
-The disk image is not encrypted.
+.IP "--help"
+Print a summary of the command line options.
 
-The image is of type VMDK or QCOW2.
-
-The boot loader uses LVM or UUID to identify the boot volume.
-
-The network configuration does not refer explictly to hardware addresses.
+.SH DIAGNOSTICS
+Returns an exit status of 0 for success or 1 if an error occured.
 
 .SH EXAMPLES
-oci-image-migrate -i /data/images/ol7.qcow2 -b thisobjectstorate -o ol7atoci -v
+.PP
+.nf
+.RS
+oci-image-migrate -i /data/images/ol7.qcow2 -b thisobjectstorage -o ol7atoci -v
+.RE
+.fi
+.PP
+Verifies if the conditions for import of the image file /data/images/ol7.qcow2
+in the
+.B Oracle Cloud Infrastructure
+are met, updates the network configuration, installs the cloud-init package,
+sets a default cloud user and uploads the modified file to the object storage
+thisobjectstorage as ol7atoci.
 
 .SH SEE ALSO
-.BR ocid (8) oci-metadata (1)
+.BR ocid (8)
+.BR oci-metadata (1)
 
-.SH BUGS
-
-.SH AUTHOR
-Guido Tijskens (guido.tijskens@oracle.com)
 
 .SH COPYRIGHT
 Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ setup(
     url="http://github.com/oracle/oci-utils/",
     package_dir={'': 'lib'},
     packages=find_packages('lib'),
-    setup_requires=[],
+    setup_requires=["flake8"],
     long_description=read('README'),
     data_files=[(os.path.join(sys.prefix, 'libexec'),
                  ['libexec/ocid',
@@ -191,6 +191,7 @@ setup(
                  ['data/ocid.service', 'data/oci-kvm-config.service']),
                 ("/etc/oci-utils",
                  ['data/oci-image-cleanup.conf',
+                  'data/oci-migrate-conf.yaml',
                   ]),
                 ("/etc/oci-utils.conf.d",
                  ['data/00-oci-utils.conf',
@@ -205,6 +206,7 @@ setup(
                   'man/man1/oci-iscsi-config.1',
                   'man/man1/oci-network-config.1',
                   'man/man1/oci-kvm.1',
+                  'man/man1/oci-image-migrate.1'
                   ]),
                 (os.path.join(sys.prefix, "share", "man", "man5"),
                  ['man/man5/oci-utils.conf.d.5',
@@ -220,6 +222,7 @@ setup(
              'bin/oci-network-config',
              'bin/oci-network-inspector',
              'bin/oci-kvm',
+             'bin/oci-image-migrate',
              ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
 
 """ Build an rpm from oci-utils.
 """
@@ -223,6 +223,7 @@ setup(
              'bin/oci-network-inspector',
              'bin/oci-kvm',
              'bin/oci-image-migrate',
+             'bin/oci-image-migrate-import'
              ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -206,7 +206,8 @@ setup(
                   'man/man1/oci-iscsi-config.1',
                   'man/man1/oci-network-config.1',
                   'man/man1/oci-kvm.1',
-                  'man/man1/oci-image-migrate.1'
+                  'man/man1/oci-image-migrate.1',
+                  'man/man1/oci-image-migrate-import.1'
                   ]),
                 (os.path.join(sys.prefix, "share", "man", "man5"),
                  ['man/man5/oci-utils.conf.d.5',


### PR DESCRIPTION
oci-image-migrate utility;
the utility verifies the prerequisited, modifies the network configuration and installs the cloud-init package; when passed, uploads the image to object storage in the OCI.
tested: OL-type and Ubuntu-type images, succeeding as well as failing on the prerequisites; the import in the custom images and creation of a working instance were tested.
.
the code is python3 compatible.
running the utility on OL8-type os is not supported yet
documentation is not up to date yet

Dec 20 2019:
updated doc; updated NetworkManager reconfiguration code; added UEFI as valid boot
tested e.a. Ubuntu16 Bios boot upload and instance creation
to be tested: UEFI boot type
to be tested: upload of real-life images