### PR TITLE
fixes for oci-kvm on OL8 using python3

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -62,6 +62,7 @@ Group: Development/Tools
 Requires: %{name} = %{version}-%{release}
 %if 0%{?rhel} >= 8
 Requires: python3-netaddr
+Requires: network-scripts
 %else
 Requires: python-netaddr
 %endif

--- a/lib/oci_utils/impl/sudo_utils.py
+++ b/lib/oci_utils/impl/sudo_utils.py
@@ -188,7 +188,7 @@ def write_to_file(path, content):
     (_, err) = subprocess.Popen(_c,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-                                stdin=subprocess.PIPE).communicate(content)
+                                stdin=subprocess.PIPE).communicate(content.encode())
     if err:
         _logger.debug("Error writing content to file: %s" % err)
         return 1


### PR DESCRIPTION
- on OL8 using ifup/ifdown requires to have NetworkScript package isntalled
- on OL8 using python3 we need to use bytes instead of str