### PR TITLE
reading the json response from the metadata endpoint should always be decoded as utf-8

### DIFF
--- a/lib/oci_utils/metadata.py
+++ b/lib/oci_utils/metadata.py
@@ -588,7 +588,7 @@ class InstanceMetadata(object):
         try:
             api_conn = urllib2.urlopen(
                 self._oci_metadata_api_url + 'instance/', timeout=2)
-            instance_metadata = json.loads(api_conn.read().decode())
+            instance_metadata = json.loads(api_conn.read().decode('utf-8'))
             metadata['instance'] = instance_metadata
         except IOError as e:
             self._errors.append(
@@ -602,7 +602,7 @@ class InstanceMetadata(object):
         try:
             api_conn = urllib2.urlopen(
                 self._oci_metadata_api_url + 'vnics/', timeout=2)
-            vnic_metadata = json.loads(api_conn.read().decode())
+            vnic_metadata = json.loads(api_conn.read().decode('utf-8'))
             metadata['vnics'] = vnic_metadata
         except IOError as e:
             self._errors.append(


### PR DESCRIPTION
if you have non ascii in your instance metadata, the json loader will fail.

```
>>> api_conn = urllib2.urlopen('http://169.254.169.254/opc/v1/instance', timeout=10)
>>> md = json.loads(api_conn.read().decode())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 10163: ordinal not in range(128)
>>>
```

by switching to utf-8 encoding, the metadata can be loaded:

```
>>> api_conn = urllib2.urlopen('http://169.254.169.254/opc/v1/instance', timeout=10)
>>> md = json.loads(api_conn.read().decode('utf-8'))
>>>
>>> md['freeformTags']
{u'displayName': u'oldag \u30b3\u30f3\u30d4\u30e5\u30fc\u30bf\u30fc\u306f\u5438\u3046'}
>>>
```
```
$ curl 169.254.169.254/opc/v1/instance/freeformTags/
{
 "displayName" : "oldag コンピューターは吸う"
}
```