### PR TITLE
fix dep version.

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -42,7 +42,7 @@ Requires: %{name} = %{version}-%{release}
 Requires: python3-netaddr
 Requires: network-scripts
 %else
-Requires: python34-netaddr
+Requires: python36-netaddr
 %endif
 
 %description kvm


### PR DESCRIPTION
On Latest Linux 7, 36 version is available
netaddr is python36-netaddr not python34-netaddr