### PR TITLE
 - cleaned up code and messages.

### DIFF
--- a/bin/oci-image-migrate-upload
+++ b/bin/oci-image-migrate-upload
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+
+# This utility assists with configuring iscsi storage on Oracle Cloud
+# Infrastructure instances.  See the manual page for more information.
+
+_PY3=/usr/bin/python3
+s_dir=`${_PY3} -c 'import os.path ; import oci_utils.impl ; print (os.path.dirname(oci_utils.impl.__file__))' 2>/dev/null`
+
+
+exec ${_PY3}  ${s_dir}/oci-image-migrate-upload-main.py $@

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
 Version: 0.11.0
-Release: 0%{?dist}
+Release: 1%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -55,6 +55,9 @@ Requires: %{name} = %{version}-%{release}
 %description outest
 Utilities unit tests
 
+# Temporary workaround
+# Does not run on OL8 due to missing nbd driver
+%if 0%{?rhel} == 7
 %package migrate
 Summary: Migrate vm from on-premise to the OCI
 Group: Development/Tools
@@ -64,6 +67,7 @@ Requires: python36-pyyaml
 Requires: qemu-img >= 15:3.1
 %description migrate
 Utilities for migrating on-premise guests to Oracle Cloud Infrastructure.
+%endif
 
 %pre
 # some old version of oci-utils, used to leave this behind.
@@ -87,6 +91,7 @@ Utilities for migrating on-premise guests to Oracle Cloud Infrastructure.
 %{__cp} -r requirements.txt %{buildroot}/opt/oci-utils
 %{__cp} -r README %{buildroot}/opt/oci-utils
 
+
 # temporary workaround to EOL vnic script: move it else where
 %{__mv} %{buildroot}/usr/libexec/secondary_vnic_all_configure.sh %{buildroot}%{python3_sitelib}/oci_utils/impl/.vnic_script.sh
 
@@ -99,10 +104,16 @@ rm -rf %{buildroot}
 %exclude %{python3_sitelib}/oci_utils/kvm/*
 %exclude %{_bindir}/oci-kvm
 %exclude %{_datadir}/man/man1/oci-kvm.1.gz
-%exclude %{_bindir}/oci-image-migrate
-%exclude %{_bindir}/oci-image-migrate-import
-%exclude %{_datadir}/man/man1/oci-image-migrate.1.gz
-%exclude %{_datadir}/man/man1/oci-image-migrate-import.1
+# Temporary workaround
+# Does not run on OL8 due to missing nbd driver
+%if 0%{?rhel} == 7
+%exclude %{_bindir}/oci-image-migrate*
+%exclude %{_datadir}/man/man1/oci-image-migrate*1.gz
+%endif
+# Temporary workaround
+# Does not run on OL8 due to missing nbd driver
+%exclude %{_sysconfdir}/oci-utils/oci-migrate-conf.yaml
+#--
 %defattr(-,root,root)
 %{python3_sitelib}/oci_utils*
 %{_bindir}/oci-*
@@ -114,8 +125,13 @@ rm -rf %{buildroot}
 %config %{_sysconfdir}/oci-utils.conf.d/00-oci-utils.conf
 %dir %attr(0755,root,root) %{_sysconfdir}/oci-utils
 %config %{_sysconfdir}/oci-utils/oci-image-cleanup.conf
+# Temporary workaround
+# Does not run on OL8 due to missing nbd driver
+%if 0%{?rhel} == 7
 %exclude %{_bindir}/oci-image-migrate
 %exclude %{_bindir}/oci-image-migrate-import
+%exclude %{_bindir}/oci-image-migrate-upload
+%endif
 %{_datadir}/man
 %exclude %{_datadir}/man/man1/oci-kvm.1.gz
 %dir %{_localstatedir}/lib/oci-utils
@@ -140,18 +156,28 @@ rm -rf %{buildroot}
 %preun kvm
 %systemd_preun oci-kvm-config.service
 
+# Temporary workaround
+# Does not run on OL8 due to missing nbd driver
+%if 0%{?rhel} == 7
 %files migrate
 %{_bindir}/oci-image-migrate
 %{_bindir}/oci-image-migrate-import
+%{_bindir}/oci-image-migrate-upload
 %{python3_sitelib}/oci_utils/__init__*
 %{python3_sitelib}/oci_utils/exceptions*
 %{python3_sitelib}/oci_utils/impl/__init__*
 %{python3_sitelib}/oci_utils/impl/oci-image-migrate*
 %{python3_sitelib}/oci_utils/migrate*
+%exclude  %{python3_sitelib}/oci_utils/migrate/tests
 %{_datadir}/man/man1/oci-image-migrate*1.gz
 %config %{_sysconfdir}/oci-utils/oci-migrate-conf.yaml
+%exclude  %{python3_sitelib}/oci_utils/migrate/tests
+%endif
 
 %changelog
+* Tue Mar 24 2020 Guido Tijskens <guido.tijskens@oracle.com. -- 0.11.1
+- add oci-image-migrate-upload, only upload image to object storage
+
 * Tue Mar 3 2020 Guido Tijskens <guido.tijskens@oracle.com> -- 0.11.0
 - add oci-image-migrate code
 

--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
 Version: 0.11.0
-Release: 1%{?dist}
+Release: 0%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -42,7 +42,7 @@ Requires: %{name} = %{version}-%{release}
 Requires: python3-netaddr
 Requires: network-scripts
 %else
-Requires: python34-netaddr
+Requires: python36-netaddr
 %endif
 
 %description kvm
@@ -175,10 +175,7 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-* Tue Mar 24 2020 Guido Tijskens <guido.tijskens@oracle.com. -- 0.11.1
-- add oci-image-migrate-upload, only upload image to object storage
-
-* Tue Mar 3 2020 Guido Tijskens <guido.tijskens@oracle.com> -- 0.11.0
+* Wed Apr 1 2020 Guido Tijskens <guido.tijskens@oracle.com> -- 0.11.0
 - add oci-image-migrate code
 
 * Wed Dec 4 2019 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.10.2

--- a/data/oci-migrate-conf.yaml
+++ b/data/oci-migrate-conf.yaml
@@ -36,7 +36,7 @@ helpers_list :
     oci        : oci-cli
 #
 # oci configuration file
-ociconfigfile : /root/.oci/config
+ociconfigfile : ~/.oci/config
 #
 # recognised file system types.
 filesystem_types :

--- a/lib/oci_utils/cache.py
+++ b/lib/oci_utils/cache.py
@@ -55,7 +55,7 @@ def get_timestamp(fname):
 
 def get_newer(fname1, fname2):
     """
-    Get the newer file, compare tiemstamp of files and return the file with
+    Get the newer file, compare timestamp of files and return the file with
     the most recent modification time.
 
     Parameters

--- a/lib/oci_utils/impl/oci-image-migrate-import-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-import-main.py
@@ -126,7 +126,6 @@ def main():
         #
         # compartment data for tenancy
         tenancy = oci_config['tenancy']
-        #console_msg(msg='Tenancy = %s' % tenancy)
         _logger.debug('Tenancy: %s' % tenancy)
         compartment_dict = migrate_utils.get_tenancy_data(tenancy)
         #
@@ -137,7 +136,6 @@ def main():
         # compartment ocid
         compartment_id = migrate_utils.find_compartment_id(compartment,
                                                            compartment_dict)
-        #console_msg(msg='Compartment ocid: %s' % compartment_id)
         #
         # object storage exist and data
         object_storage_data = migrate_utils.bucket_exists(bucket)

--- a/lib/oci_utils/impl/oci-image-migrate-upload-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-upload-main.py
@@ -88,25 +88,19 @@ def main():
     # input image
     if cmdline_args.input_image:
         image_path = cmdline_args.input_image.name
-        migrate_tools.result_msg(msg='\n  Running %s at %s\n'
-                                     % (os.path.basename(' '.join(sys.argv)),
-                                        time.ctime()), flags='w', result=True)
+        console_msg(msg='\n  Running %s at %s\n'
+                        % (os.path.basename(' '.join(sys.argv)), time.ctime()))
     else:
         raise OciMigrateException('Missing argument: input image path.')
     #
     # object storage
     bucket_name = cmdline_args.bucket_name
-    console_msg(msg='Uploading %s to object storage %s in the Oracle Cloud '
-                    'Infrastructure as %s.' % (image_path,
-                                               bucket_name,
-                                               cmdline_args.output_name))
     #
     # output image
     if cmdline_args.output_name:
         output_name = cmdline_args.output_name
     else:
         output_name = os.path.splitext(os.path.basename(image_path))[0]
-    migrate_tools.result_msg(msg='Output name:  %s\n' % output_name, result=True)
     verbose_flag = cmdline_args.verbose_flag
     #
     # message
@@ -156,14 +150,13 @@ def main():
                           % (output_name, bucket_name))
         #
         # Upload the image.
-        migrate_tools.result_msg(msg='\n  Uploading %s, this might take a while....'
-                                 % image_path, result=True)
+        console_msg(msg='\n  Uploading %s, this might take a while....' % image_path)
         upload_progress.start()
         upload_result = migrate_utils.upload_image(image_path,
                                                    bucket_name,
                                                    output_name)
         _logger.debug('Upload result: %s' % upload_result)
-        migrate_tools.result_msg(msg='  Finished....\n', result=True)
+        console_msg(msg='  Finished....\n')
         upload_progress.stop()
     except Exception as e:
         _logger.error('  Error while uploading %s to %s: %s.'

--- a/lib/oci_utils/impl/oci-image-migrate-upload-main.py
+++ b/lib/oci_utils/impl/oci-image-migrate-upload-main.py
@@ -1,0 +1,180 @@
+# oci-utils
+#
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown
+# at http://oss.oracle.com/licenses/upl.
+
+"""
+Script to upload an on-premise image of a virtual server to an object storage
+in the Oracle Cloud Infrastructure.
+"""
+import argparse
+import json
+import logging.config
+import os
+import sys
+import time
+
+from oci_utils.migrate import console_msg, exit_with_msg, get_config_data, \
+    read_yn, terminal_dimension
+from oci_utils.migrate import migrate_tools
+from oci_utils.migrate import migrate_utils
+from oci_utils.migrate.exception import OciMigrateException
+
+if sys.version_info.major < 3:
+    exit_with_msg('Python version 3 is a requirement to run this utility.')
+
+_logger = logging.getLogger('oci-utils.import_up')
+
+
+def parse_args():
+    """
+    Parse the command line arguments and return an object representing the
+    command
+    line as returned by the argparse's parse-args().
+    arguments:
+    -i|--image-name <image name>; mandatory.
+    -b|--bucket-name <bucket name>; mandatory.
+    -o|--output-name <output image name>; optional
+
+    Returns
+    -------
+        The command line namespace.
+    """
+    parser = argparse.ArgumentParser(
+        description='Utility to upload on-premise legacy images to object '
+                    'storage of the Oracle Cloud Infrastructure.',
+        add_help=False)
+    #
+    parser.add_argument('-i', '--image-name',
+                        action='store',
+                        dest='input_image',
+                        type=argparse.FileType('r'),
+                        required=True,
+                        help='The on-premise image name uploaded image.')
+    parser.add_argument('-b', '--bucket-name',
+                        action='store',
+                        dest='bucket_name',
+                        required=True,
+                        help='The name of the object storage.')
+    parser.add_argument('-o', '--output-name',
+                        action='store',
+                        dest='output_name',
+                        help='The name the image will be stored in the object '
+                             'storage.')
+    parser.add_argument('--verbose', '-v',
+                        action='store_true',
+                        dest='verbose_flag',
+                        default=False,
+                        help='Show verbose information.')
+    parser.add_argument('--help', action='help', help='Display this help')
+    parser._optionals.title = 'Arguments'
+    args = parser.parse_args()
+    if args.output_name is None:
+        args.output_name = args.image_name
+    return args
+
+
+def main():
+    #
+    # set locale
+    lc_all_to_set = get_config_data('lc_all')
+    os.environ['LC_ALL'] = "%s" % lc_all_to_set
+    _logger.debug('Locale set to %s' % lc_all_to_set)
+    #
+    # command line
+    cmdline_args = parse_args()
+    #
+    # input image
+    if cmdline_args.input_image:
+        image_path = cmdline_args.input_image.name
+        migrate_tools.result_msg(msg='\n  Running %s at %s\n'
+                                     % (os.path.basename(' '.join(sys.argv)),
+                                        time.ctime()), flags='w', result=True)
+    else:
+        raise OciMigrateException('Missing argument: input image path.')
+    #
+    # object storage
+    bucket_name = cmdline_args.bucket_name
+    console_msg(msg='Uploading %s to object storage %s in the Oracle Cloud '
+                    'Infrastructure as %s.' % (image_path,
+                                               bucket_name,
+                                               cmdline_args.output_name))
+    #
+    # output image
+    if cmdline_args.output_name:
+        output_name = cmdline_args.output_name
+    else:
+        output_name = os.path.splitext(os.path.basename(image_path))[0]
+    migrate_tools.result_msg(msg='Output name:  %s\n' % output_name, result=True)
+    verbose_flag = cmdline_args.verbose_flag
+    #
+    # message
+    console_msg(msg='Uploading %s to object storage %s in the Oracle Cloud '
+                    'Infrastructure as %s.' % (image_path,
+                                               bucket_name,
+                                               output_name))
+    #
+    # collect data
+    try:
+        #
+        # The oci configuration.
+        oci_config = migrate_utils.get_oci_config()
+        _logger.debug('Found oci config file')
+        #
+        # The object storage exist and data.
+        object_storage_data = migrate_utils.bucket_exists(bucket_name)
+        console_msg(msg='Object storage %s present.' % bucket_name)
+        #
+        # The object is present in object storage.
+        if migrate_utils.object_exists(object_storage_data, output_name):
+            raise OciMigrateException('Object %s already exists object '
+                                      'storage %s.' % (output_name, bucket_name))
+        else:
+            _logger.debug('Object %s does not yet exists in object storage %s'
+                          % (output_name, bucket_name))
+    except Exception as e:
+        exit_with_msg('Failed to collect essential data: %s' % str(e))
+    #
+    # Ask for confirmation to proceed.
+    if not read_yn('\n  Agree to proceed uploading %s to %s as %s?'
+                   % (image_path, bucket_name, output_name), waitenter=True):
+        exit_with_msg('\n  Exiting.')
+    #
+    # Uploading the image to the Oracle Cloud Infrastructure.
+    _, nbcols = terminal_dimension()
+    try:
+        upload_progress = migrate_tools.ProgressBar(
+            nbcols, 0.2, progress_chars=['uploading %s' % output_name])
+        #
+        # Verify if object already exists.
+        if migrate_utils.object_exists(object_storage_data, output_name):
+            raise OciMigrateException('Object %s already exists object '
+                                      'storage %s.' % (output_name, bucket_name))
+        else:
+            _logger.debug('Object %s does not yet exists in object storage %s'
+                          % (output_name, bucket_name))
+        #
+        # Upload the image.
+        migrate_tools.result_msg(msg='\n  Uploading %s, this might take a while....'
+                                 % image_path, result=True)
+        upload_progress.start()
+        upload_result = migrate_utils.upload_image(image_path,
+                                                   bucket_name,
+                                                   output_name)
+        _logger.debug('Upload result: %s' % upload_result)
+        migrate_tools.result_msg(msg='  Finished....\n', result=True)
+        upload_progress.stop()
+    except Exception as e:
+        _logger.error('  Error while uploading %s to %s: %s.'
+                      % (image_path, bucket_name, str(e)))
+        exit_with_msg('*** ERROR *** Error while uploading %s to %s: %s.'
+                      % (image_path, bucket_name, str(e)))
+    finally:
+        # if progress thread was started, needs to be terminated.
+        if migrate_tools.isthreadrunning(upload_progress):
+            upload_progress.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/oci_utils/migrate/__init__.py
+++ b/lib/oci_utils/migrate/__init__.py
@@ -126,7 +126,31 @@ def console_msg(msg=None):
 
 
 def bytes_to_hex(bs):
+    """
+    Convert a byte string to an hex string.
+
+    Parameters
+    ----------
+    bs: str
+       byte string
+
+    Returns
+    -------
+        str: hex string
+    """
     return ''.join('%02x' % i for i in bs)
+
+
+def terminal_dimension():
+    """
+    Collect the dimension of the terminal window.
+
+    Returns
+    -------
+        tuple: (nb rows, nb colums)
+    """
+    rowstr, colstr = os.popen('stty size', 'r').read().split()
+    return int(rowstr), int(colstr)
 
 
 class OciMigrateConfParam(object):

--- a/lib/oci_utils/migrate/doc/oci_image_migrate_upload.md
+++ b/lib/oci_utils/migrate/doc/oci_image_migrate_upload.md
@@ -1,0 +1,60 @@
+# oci-utils.oci-image-migrate-upload
+
+## Introduction
+
+oci-image-migrate-upload uploads an on-premise image to an object storage
+of the Oracle Cloud Infrastructure.
+
+## Usage
+```
+   $ oci-image-migrate-upload --help
+   usage: oci-image-migrate-upload-main.py -i INPUT_IMAGE 
+                                           -b BUCKET_NAME
+                                           [-o OUTPUT_NAME]
+                                           [--verbose] 
+                                           [--help]
+
+   Utility to upload on-premise legacy images to object storage of the Oracle
+   Cloud Infrastructure.
+
+   Arguments:
+  -i INPUT_IMAGE, --image-name INPUT_IMAGE
+                        The on-premise image name uploaded image.
+  -b BUCKET_NAME, --bucket-name BUCKET_NAME
+                        The name of the object storage.
+  -o OUTPUT_NAME, --output-name OUTPUT_NAME
+                        The name the image will be stored in the object
+                        storage.
+  --verbose, -v         Show verbose information.
+  --help                Display this help
+```
+
+The environment variable _OCI_UTILS_DEBUG changes the logging level of
+the python code.
+
+## Installation
+
+### Prerequisites
+
+   1. The git package is installed.
+
+   1. The oci cli package is installed and configured.
+
+### The install
+
+1. Pull the software from github:
+
+       # git clone https://github.com/guidotijskens/oci-utils.git
+
+1. Checkout the migrate branch:
+
+       # git checkout migrate
+
+1. Build the rpm:
+
+       # cd oci-utils
+       # python3 ./setup.py -c create-rpm
+
+1. Install the rpm:
+
+       # yum localinstall oci-utils/rpmbuild/RPMS/noarch/oci-utils-migrate

--- a/lib/oci_utils/migrate/imgdevice.py
+++ b/lib/oci_utils/migrate/imgdevice.py
@@ -17,7 +17,8 @@ import threading
 import time
 from glob import glob as glob
 
-from oci_utils.migrate import bytes_to_hex, console_msg, pause_msg
+from oci_utils.migrate import bytes_to_hex, console_msg, \
+    pause_msg, terminal_dimension
 from oci_utils.migrate import get_config_data
 from oci_utils.migrate import migrate_tools
 from oci_utils.migrate import migrate_utils
@@ -81,9 +82,9 @@ class UpdateImage(threading.Thread):
                 'Installing the cloud-init package, this might take a while.')
             #
             # create progressbar here
-            _, clmns = os.popen('stty size', 'r').read().split()
+            _, nbcols = terminal_dimension()
             cloud_init_install = migrate_tools.ProgressBar(
-                int(clmns), 0.2, progress_chars=['installing cloud-init'])
+                nbcols, 0.2, progress_chars=['installing cloud-init'])
             cloud_init_install.start()
             #
             # chroot
@@ -426,8 +427,8 @@ class DeviceData(object):
                              exc_info=False)
             return False
         finally:
-            _, clmns = os.popen('stty size', 'r').read().split()
-            cleanup = migrate_tools.ProgressBar(int(clmns), 0.2,
+            _, nbcols = terminal_dimension()
+            cleanup = migrate_tools.ProgressBar(nbcols, 0.2,
                                                 progress_chars=['cleaning up'])
             cleanup.start()
             #

--- a/lib/oci_utils/migrate/readme.txt
+++ b/lib/oci_utils/migrate/readme.txt
@@ -1,4 +1,9 @@
 #
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
+
+#
 # definition of supported image formats:
 # dictionary of dictionaries,
 #  main key is the magic number,

--- a/man/man1/oci-image-migrate-import.1
+++ b/man/man1/oci-image-migrate-import.1
@@ -2,8 +2,9 @@
 .\" groff -man -Tascii oci-image-migrate-import.1
 .\"
 .\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
-.\"
-
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
+./"
 .TH OCI-IMAGE-MIGRATE 1 "JAN 2020" Linux "User Manuals"
 .SH NAME
 oci-image-migrate-import \- assist the import of an image in the 

--- a/man/man1/oci-image-migrate-import.1
+++ b/man/man1/oci-image-migrate-import.1
@@ -4,7 +4,7 @@
 .\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 .\" Licensed under the Universal Permissive License v 1.0 as shown
 .\" at http://oss.oracle.com/licenses/upl.
-./"
+.\"
 .TH OCI-IMAGE-MIGRATE 1 "JAN 2020" Linux "User Manuals"
 .SH NAME
 oci-image-migrate-import \- assist the import of an image in the 

--- a/man/man1/oci-image-migrate-upload.1
+++ b/man/man1/oci-image-migrate-upload.1
@@ -2,8 +2,9 @@
 .\" groff -man -Tascii oci-image-migrate-upload.1
 .\"
 .\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
-
 .TH OCI-IMAGE-MIGRATE 1 "JAN 2020" Linux "User Manuals"
 .SH NAME
 oci-image-migrate-upload \- assist the upload of an on-premise image to the

--- a/man/man1/oci-image-migrate-upload.1
+++ b/man/man1/oci-image-migrate-upload.1
@@ -1,40 +1,37 @@
 .\" Process this file with
-.\" groff -man -Tascii oci-image-migrate-import.1
+.\" groff -man -Tascii oci-image-migrate-upload.1
 .\"
 .\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
 .\"
 
 .TH OCI-IMAGE-MIGRATE 1 "JAN 2020" Linux "User Manuals"
 .SH NAME
-oci-image-migrate-import \- assist the import of an image in the 
+oci-image-migrate-upload \- assist the upload of an on-premise image to the
 .B object storage
-to the 
-.B custom images
-repository of the Oracle Cloud Infrastructure
+of the Oracle Cloud Infrastructure
 .SH SYNOPSIS
-.B oci-image-migrate-import  [-i|--image-name
+.B oci-image-migrate-upload  [-i|--image-name
 .I image name
 .B ] [-b|--bucket-name
 .I bucket_name
-.B ] [-c|--compartment-name
-.I compartment name
-.B ] [-d|--display-name
-.I display name
-.B ] [-l|--launch-mode
-.I [PARAVIRTUALIZED|EMULATED|NATIVE]
+.B ] [-o|--output-name
+.I output name
 .B ] [-v|--verbose] [--help]
 
 .SH DESCRIPTION
 The
-.B oci-image-migrate-import
-utility imports an image file residing in an object storage into the custom 
-images repository of
+.B oci-image-migrate-upload
+utility uploads an on-premise image file to the
+.B object storage
+of the
 .B Oracle Cloud Infrastructure.
 
-.B oci-image-migrate-import
-verifies the existence of the image file and the object storage.
+.B oci-image-migrate-upload
+verifies the existence of the on-premise image file, of the
+.B object storage.
 It also checks if and image with the same name already exists
-in the object storage.
+in the
+.B object storage.
 
 .B oci-image-migrate-import
 does not need to be run with root priviliges as long as the user has the
@@ -42,6 +39,7 @@ correct priviliges to access the
 .B Oracle Cloud Infrastructure
 and write priviliges in the directory where log and result files are written,
 as well as in the log file itself (by default /var/tmp/oci-utils.log).
+
 
 .B oci-image-migrate-import
 requires the
@@ -56,22 +54,16 @@ for more information.
 
 .SH OPTIONS
 .IP "-i|--image-name"
-The name of the on-premise image. This option is mandatory.
+The name of the image as present in the object storage. This option is mandatory.
 .IP "-b|--bucket-name"
 The name of the object storage or bucket in the
 .B Oracle Cloud Infrastructure
 where the imagefile is to be stored. This option is mandatory.
-.IP "-c|--compartment-name"
-The name of the destination compartment. This option is mandatory.
-.IP "-d|--display-name"
-The image name or the name the image will be saved in the
-.B custom images
-repository in the
+.IP "-o|--output-name"
+The image name or the name of the image as it will be stored in the
+.B object storage of the
 .B Oracle Cloud Infrastructure.
 This argument is optional, the default is the image name.
-.IP "-l|--launch-mode"
-The mode an instance created form the custom image will be started. Possible
-modes are PARAVIRTUALIZED, EMULATED and NATIVE. The default is PARAVIRTUALIZED.
 .IP "-v|--verbose"
 Show more information about the import on the console.
 .IP "--help"
@@ -84,17 +76,17 @@ Returns an exit status of 0 for success or 1 if an error occured.
 .PP
 .nf
 .RS
-oci-image-migrate-import --image-name /images/OracleLinux7.vmdk -b MyObjectStorage -C MyCompartment -l EMULATED --display-name OracleLinux7U7 -v
+oci-image-migrate-upload --image-name /images/OracleLinux7.vmdk -b MyObjectStorage --output-name OracleLinux7U7 -v
 .RE
 .fi
 .PP
-Imports the image file /images/OracleLinux7.vmdk, on condition it exists, to the object storage of
+Uploads the image file /images/OracleLinux7.vmdk , if it exists on premise to the object MyObjectStorage of the
 .B Oracle Cloud Infrastructure
-as OracleLinux7U7 if there is not yet and image with the same name present.
+as OracleLinux7U7 on condition there is not yet and image with the same name present.
 
 .SH SEE ALSO
 .BR oci-image-migrate(1)
-.BR oci-image-migrate-upload(1)
+.BR oci-image-migrate-import(1)
 .BR ocid (8)
 .BR oci-metadata (1)
 

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -1,7 +1,9 @@
 .\" Process this file with
 .\" groff -man -Tascii oci-image-migrate.1
 .\"
-.\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-IMAGE-MIGRATE 1 "JUNE 2019" Linux "User Manuals"
 .SH NAME

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -3,7 +3,6 @@
 .\"
 .\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
 .\"
-
 .TH OCI-IMAGE-MIGRATE 1 "JUNE 2019" Linux "User Manuals"
 .SH NAME
 oci-image-migrate \- assist the migration of on premise virtual machines to the

--- a/man/man1/oci-image-migrate.1
+++ b/man/man1/oci-image-migrate.1
@@ -54,7 +54,7 @@ The full path name of the on-premise custom image. This option is mandatory.
 .IP "-b|--bucket"
 The name of the object storage or bucket in the
 .B Oracle Cloud Infrastructure,
- the destination of the modified image file. This options is mandatory.
+ the destination of the modified image file. This option is mandatory.
 .IP "-o|--output-image"
 The oci-image-name or the name of the image as it will be saved in the object
 storage in
@@ -75,18 +75,20 @@ Returns an exit status of 0 for success or 1 if an error occured.
 .PP
 .nf
 .RS
-oci-image-migrate -i /data/images/ol7.qcow2 -b thisobjectstorage -o ol7atoci -v
+oci-image-migrate -i /data/images/Ubuntu1804.qcow2 -b MyObjectStorage -o Ubuntu1804LTS -v
 .RE
 .fi
 .PP
-Verifies if the conditions for import of the image file /data/images/ol7.qcow2
+Verifies if the conditions for import of the image file /data/images/Ubuntu1804.qcow2
 in the
 .B Oracle Cloud Infrastructure
 are met, updates the network configuration, installs the cloud-init package,
 sets a default cloud user and uploads the modified file to the object storage
-thisobjectstorage as ol7atoci.
+MyObjectStorage as Ubuntu1804LTS.
 
 .SH SEE ALSO
+.BR oci-image-migrate-upload(1)
+.BR oci-image-migrate-import(1)
 .BR ocid (8)
 .BR oci-metadata (1)
 

--- a/man/man1/oci-iscsi-config.1
+++ b/man/man1/oci-iscsi-config.1
@@ -2,8 +2,9 @@
 .\" groff -man -Tascii oci-iscsi-config.1
 .\"
 .\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
-
 .TH OCI-ISCSI-CONFIG 1 "MAY 2018" Linux "User Manuals"
 .SH NAME
 oci-iscsi-config \- configure iSCSI devices on Oracle Cloud Infrastructure compute instances

--- a/man/man1/oci-kvm.1
+++ b/man/man1/oci-kvm.1
@@ -2,6 +2,8 @@
 .\" groff -man -Tascii oci-kvm.1
 .\"
 .\" Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-KVM 1 "AUGUST 2019" Linux "User Manuals"
 .SH NAME

--- a/man/man1/oci-metadata.1
+++ b/man/man1/oci-metadata.1
@@ -2,6 +2,8 @@
 .\" groff -man -Tascii oci-metadata.1
 .\"
 .\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-METADATA 1 "MAY 2018" Linux "User Manuals"
 .SH NAME

--- a/man/man1/oci-network-config.1
+++ b/man/man1/oci-network-config.1
@@ -2,6 +2,8 @@
 .\" groff -man -Tascii oci-network-config.1
 .\"
 .\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-NETWORK-CONFIG 1 "MAY 2018" Linux "User Manuals"
 .SH NAME

--- a/man/man1/oci-network-inspector.1
+++ b/man/man1/oci-network-inspector.1
@@ -2,6 +2,8 @@
 .\" groff -man -Tascii oci-network-inspector.1
 .\"
 .\" Copyright(c) 2018 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-NETWORK-INSPECTOR 1 "AUG 2018" Linux "User Manuals"
 .SH NAME

--- a/man/man1/oci-public-ip.1
+++ b/man/man1/oci-public-ip.1
@@ -2,6 +2,8 @@
 .\" groff -man -Tascii oci-public-ip.1
 .\"
 .\" Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+.\" Licensed under the Universal Permissive License v 1.0 as shown
+.\" at http://oss.oracle.com/licenses/upl.
 .\"
 .TH OCI-PUBLIC-IP 1 "MAY 2018" Linux "User Manuals"
 .SH NAME

--- a/setup.py
+++ b/setup.py
@@ -380,6 +380,7 @@ setup(
                   'man/man1/oci-kvm.1',
                   'man/man1/oci-image-migrate.1',
                   'man/man1/oci-image-migrate-import.1',
+                  'man/man1/oci-image-migrate-upload.1',
                   ]),
                 (os.path.join(sys.prefix, "share", "man", "man5"),
                  ['man/man5/oci-utils.conf.d.5',
@@ -406,6 +407,7 @@ setup(
              'bin/oci-kvm',
              'bin/oci-image-migrate',
              'bin/oci-image-migrate-import',
+             'bin/oci-image-migrate-upload',
              ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 
 # Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# http://oss.oracle.com/licenses/upl.
 
 """ Build an rpm from oci-utils.
 """


### PR DESCRIPTION
 - cleaned up code and messages, removed and modified console and debug messages, reducing possible confusion.
 - added oci-image-migrate-upload code: a separate script to upload a (verified and modified) on premise image to object storage in the OCI only; the oci-image-migrate script still has the upload part, but by separting thig, the image can be uploaded more than once, to different object storage, without the need to go through the verification and modification.
 - modified code so upload and import can be run as non-root user; the upload and import do not need the root user, the verification/modification does due to the mount and package install operations.
 - updated spec file so oci-utils-migrate...el8.noarch.rpm is not build, is not yet supported; due to the absence of the nbd kernel module in OL8/RH8, the oci-image-migrate script will not run, building the el8 rpm would cause confusion and bug reports. This is is being worked on.
- removed the tests from the rpm, they are not yet complete.
.
the changes have been tested with real life images.

