### PR TITLE
remove python version switch: use only python3

### DIFF
--- a/libexec/oci-kvm-config.sh
+++ b/libexec/oci-kvm-config.sh
@@ -62,15 +62,6 @@ do
   fi
 done
 
-# Perform any necessary upgrades
 
-. /etc/os-release
-major=`echo $VERSION_ID | ${_CUT} -d. -f1`
-if [ ${major} -ge 8 ]
-then
-   #priority given to python3
-   /usr/bin/python3  /usr/libexec/oci-kvm-upgrade
-else
-   /usr/bin/python2  /usr/libexec/oci-kvm-upgrade
-fi
+/usr/bin/python3  /usr/libexec/oci-kvm-upgrade
 


### PR DESCRIPTION
We used to have a switch according to the platform to use python2 or python3
We only support python3 now : remove that switch