### PR TITLE
wrong usage of bytes cause KVM utils to fail parsing platform assets

### DIFF
--- a/lib/oci_utils/impl/network_helpers.py
+++ b/lib/oci_utils/impl/network_helpers.py
@@ -88,8 +88,8 @@ def get_interfaces():
                 # TODO: virtual functions
                 for line in subprocess.check_output(
                         ['/usr/sbin/ip', 'link', 'show', n]).splitlines():
-                    line = line.strip()
-                    if not str(line).startswith('vf '):
+                    line = line.strip().decode()
+                    if not line.startswith('vf '):
                         continue
 
                     ents = line.split(' ')

--- a/lib/oci_utils/impl/platform_helpers.py
+++ b/lib/oci_utils/impl/platform_helpers.py
@@ -32,10 +32,11 @@ def get_phys_device():
         return None
     phys_dev = None
     output = sudo_utils.call_output([IP_CMD, '-o', '-4', 'addr', 'show'])
-    lines = str(output).split('\n')
+    lines = output.splitlines()
     for line in lines:
-        if private_ip in line.strip():
-            phys_dev = line.strip().split()[1]
+        _l = line.decode().strip()
+        if private_ip in _l:
+            phys_dev = _l.split()[1]
     _logger.debug('%s physical devices found' % len(phys_dev))
     return phys_dev
 

--- a/lib/oci_utils/impl/virt/virt_check.py
+++ b/lib/oci_utils/impl/virt/virt_check.py
@@ -90,7 +90,7 @@ def br_link_mode_check(phys_dev):
     vepa = "VEPA"
     res = sudo_utils.call_popen_output(
         [BRIDGE_CMD, 'link', 'show', 'dev', '"{}"'.format(phys_dev)])
-    if res and vepa == res.split()[-1]:
+    if res and vepa == res.split()[-1].decode().upper():
         return True
     _logger.debug('br_link_mode_check, return False, server_type: %s ' % vepa)
     return False
@@ -113,15 +113,19 @@ def validate_kvm_env(check_for_bm_shape=True):
     """
     phys_dev = get_phys_device()
     if phys_dev is None:
+        _logger.debug('No physical device found')
         return False
 
     if not iommu_check():
+        _logger.debug('iommu_check failed')
         return False
 
     if check_for_bm_shape:
         if not sriov_numvfs_check(phys_dev):
+            _logger.debug('sriov_numvfs_check failed')
             return False
         if not br_link_mode_check(phys_dev):
+            _logger.debug('br_link_mode_check failed')
             return False
     return True
 

--- a/lib/oci_utils/kvm/nic.py
+++ b/lib/oci_utils/kvm/nic.py
@@ -72,7 +72,7 @@ def get_interfaces():
                 # TODO: virtual functions
                 for line in subprocess.check_output(
                         ['/usr/sbin/ip', 'link', 'show', n]).splitlines():
-                    line = line.strip()
+                    line = line.strip().decode()
                     if not line.startswith('vf '):
                         continue
 

--- a/lib/oci_utils/lsblk.py
+++ b/lib/oci_utils/lsblk.py
@@ -52,7 +52,7 @@ def list():
                  '-o', 'NAME,FSTYPE,MOUNTPOINT,SIZE,PKNAME'], stderr=DEVNULL).decode('utf-8')
         devices = {}
         # with python3, output id byte-like object, cast it to str
-        for line in str(output).split('\n'):
+        for line in output.splitlines():
             match = _LSBLK_PATTERN.match(line.strip())
             if match:
                 dev = match.group(1)


### PR DESCRIPTION
Issue is from python3 "str vs bytes "  management. while listing physical network device to find available VFs , we only check on LO interface and other ones (the real physical network interfaces) has been discarded 
we wrongly cast bytes to str using the str(). method.

testing :  successfully created a guest 

```
[root@kchepart-kvm-bm opc]# /usr/bin/python3 -mpdb /usr/lib/python3.6/site-packages/oci_utils/impl/virt/oci-kvm-main.py create -D kvm_guest1 --disk /dev/sdb -V --vcpus 4 --memory 8192 --boot cdrom,hd --location /tmp/OracleLinux-R7-U8-Server-x86_64-dvd.iso --nographics --console pty,target_type=serial --console pty,target_type=virtio --noautoconsole --os-variant=rhel7 --extra-args “console=ttyS0”

Autoconsole has been disabled. To view the console, issue 'virsh console kvm_guest1'
The program exited via sys.exit(). Exit status: 0

````

[root@kchepart-kvm-bm opc]# virsh list --all
setlocale: No such file or directory
 Id   Name         State
----------------------------
 1    kvm_guest1   running

