### PR TITLE
libvirt pool based on uuid of device

### DIFF
--- a/lib/oci_utils/impl/__init__.py
+++ b/lib/oci_utils/impl/__init__.py
@@ -20,7 +20,7 @@ from time import sleep
 from ..exceptions import OCISDKError
 
 __all__ = ['lock_thread', 'release_thread', 'read_config', 'SUDO_CMD',
-           'CAT_CMD', 'SH_CMD', 'CP_CMD', 'TOUCH_CMD', 'CHMOD_CMD']
+           'CAT_CMD', 'SH_CMD', 'CP_CMD', 'TOUCH_CMD', 'CHMOD_CMD', 'LSBLK_CMD']
 
 CAT_CMD = '/usr/bin/cat'
 TOUCH_CMD = '/usr/bin/touch'
@@ -35,6 +35,7 @@ BRIDGE_CMD = '/sbin/bridge'
 PARTED_CMD = '/sbin/parted'
 MK_XFS_CMD = '/sbin/mkfs.xfs'
 SYSTEMCTL_CMD = '/bin/systemctl'
+LSBLK_CMD = '/bin/lsblk'
 
 
 def print_error(msg, *args):
@@ -192,23 +193,23 @@ def read_config():
     oci_utils_config = ConfigParser()
     # assign default
     oci_utils_config.add_section('auth')
-    oci_utils_config.set('auth','auth_method','auto')
-    oci_utils_config.set('auth','oci_sdk_user','opc')
+    oci_utils_config.set('auth', 'auth_method', 'auto')
+    oci_utils_config.set('auth', 'oci_sdk_user', 'opc')
     oci_utils_config.add_section('iscsi')
-    oci_utils_config.set('iscsi','enabled','true')
-    oci_utils_config.set('iscsi','scan_interval','60')
-    oci_utils_config.set('iscsi','max_volumes','8')
-    oci_utils_config.set('iscsi','auto_resize','true')
-    oci_utils_config.set('iscsi','auto_detach','true')
-    oci_utils_config.set('iscsi','detach_retry','5')
+    oci_utils_config.set('iscsi', 'enabled', 'true')
+    oci_utils_config.set('iscsi', 'scan_interval', '60')
+    oci_utils_config.set('iscsi', 'max_volumes', '8')
+    oci_utils_config.set('iscsi', 'auto_resize', 'true')
+    oci_utils_config.set('iscsi', 'auto_detach', 'true')
+    oci_utils_config.set('iscsi', 'detach_retry', '5')
     oci_utils_config.add_section('vnic')
-    oci_utils_config.set('vnic','enabled','true')
-    oci_utils_config.set('vnic','scan_interval','60')
-    oci_utils_config.set('vnic','vf_net','false')
+    oci_utils_config.set('vnic', 'enabled', 'true')
+    oci_utils_config.set('vnic', 'scan_interval', '60')
+    oci_utils_config.set('vnic', 'vf_net', 'false')
     oci_utils_config.add_section('public_ip')
-    oci_utils_config.set('public_ip','enabled','true')
-    oci_utils_config.set('public_ip','refresh_interval','600')
-    
+    oci_utils_config.set('public_ip', 'enabled', 'true')
+    oci_utils_config.set('public_ip', 'refresh_interval', '600')
+
     if not os.path.exists(__oci_utils_conf_d):
         return oci_utils_config
 

--- a/lib/oci_utils/kvm/virt.py
+++ b/lib/oci_utils/kvm/virt.py
@@ -22,7 +22,7 @@ from netaddr import IPNetwork
 from string import Template
 
 from . import nic
-from ..impl import IP_CMD, SUDO_CMD, PARTED_CMD, MK_XFS_CMD, print_choices, print_error, VIRSH_CMD
+from ..impl import IP_CMD, SUDO_CMD, PARTED_CMD, MK_XFS_CMD, print_choices, print_error, VIRSH_CMD, LSBLK_CMD
 from ..impl import sudo_utils
 from ..impl.network_helpers import get_interfaces
 from ..impl.network_helpers import add_route_table
@@ -39,7 +39,6 @@ from ..impl.init_script_helpers import SystemdServiceManager
 
 
 _logger = logging.getLogger('oci-utils.kvm.virt')
-
 
 
 def _print_available_vnics(vnics):
@@ -363,8 +362,8 @@ def create_networking(vf_device, vlan, mac, ip=None, prefix=None):
         else:
             vlan_cfg = sysconfig.make_vlan(vf_device, vlan, mac)
         cfg = {vf_cfg[0]: vf_cfg[1],
-                vlan_cfg[0]: vlan_cfg[1]
-           }
+               vlan_cfg[0]: vlan_cfg[1]
+               }
         sysconfig.write_network_config(cfg)
         return sysconfig.interfaces_up([vf_cfg[0], vlan_cfg[0]])
     else:
@@ -375,6 +374,7 @@ def create_networking(vf_device, vlan, mac, ip=None, prefix=None):
         cfg = {vf_cfg[0]: vf_cfg[1]}
         sysconfig.write_network_config(cfg)
         return sysconfig.interfaces_up([vf_cfg[0]])
+
 
 def destroy_networking(vf_device, vlan=None):
     """
@@ -400,6 +400,7 @@ def destroy_networking(vf_device, vlan=None):
         sysconfig.delete_network_config([vlan_name, vf_name])
     else:
         sysconfig.delete_network_config([vf_name])
+
 
 def destroy_interface(name):
     """
@@ -561,10 +562,11 @@ def create(**kargs):
                     if intf_name == kargs['network']:
                         _mac_to_use = intf_info['mac'].upper()
                 if _mac_to_use is None:
-                    _logger.debug('warning: cannot find MAC address for %s'%kargs['network'])
+                    _logger.debug('warning: cannot find MAC address for %s' % kargs['network'])
                     args.append('type=direct,model=virtio,source_mode=passthrough,source=%s' % kargs['network'])
                 else:
-                    args.append('type=direct,model=virtio,source_mode=passthrough,source=%s,mac=%s' % (kargs['network'], _mac_to_use))
+                    args.append('type=direct,model=virtio,source_mode=passthrough,source=%s,mac=%s' %
+                                (kargs['network'], _mac_to_use))
             else:
                 # have to find one free interface. i.e not already used by a guest
                 # and not the primary one. the VNICs returned by metadata service is sorted list
@@ -592,13 +594,14 @@ def create(**kargs):
                     return 1
 
                 args.append('--network')
-                args.append('type=direct,model=virtio,source_mode=passthrough,source=%s,mac=%s' % (intf_to_use,_mac_to_use))
+                args.append('type=direct,model=virtio,source_mode=passthrough,source=%s,mac=%s' %
+                            (intf_to_use, _mac_to_use))
 
     args.extend(kargs['extra_args'])
 
     if '--console' in kargs['extra_args']:
         args.append('--noautoconsole')
-        print("Autoconsole has been disabled. To view the console, issue " \
+        print("Autoconsole has been disabled. To view the console, issue "
               "'virsh console {}'".format(kargs['name']))
 
     _logger.debug('create: executing [%s]' % ' '.join(args))
@@ -795,16 +798,19 @@ def create_fs_pool(disk, name):
         print_error('Failed to make xfs filesystem on new prtition')
         return 1
 
-    if sudo_utils.call([VIRSH_CMD, '--quiet', 'pool-define-as', '--name=%s'%name, '--type=fs', '--source-dev=%s'%_new_part,'--target=/oci-%s'%name]):
+    # grab the uuid of the device
+    _uuid = sudo_utils.call_output([LSBLK_CMD, '--output', 'uuid', '--noheadings', _new_part])
+
+    if sudo_utils.call([VIRSH_CMD, '--quiet', 'pool-define-as', '--name=%s' % name, '--type=fs', '--source-dev=/dev/disk/by-uuid/%s' % _uuid, '--target=/oci-%s' % name]):
         print_error('Failed to define pool')
         return 1
 
-    if sudo_utils.call([VIRSH_CMD, '--quiet','pool-build', name]):
+    if sudo_utils.call([VIRSH_CMD, '--quiet', 'pool-build', name]):
         print_error('Failed to build pool')
         sudo_utils.call([VIRSH_CMD, 'pool-undefine', name])
         return 1
 
-    if sudo_utils.call([VIRSH_CMD, '--quiet','pool-start', name]):
+    if sudo_utils.call([VIRSH_CMD, '--quiet', 'pool-start', name]):
         sudo_utils.call([VIRSH_CMD, 'pool-undefine', name])
         print_error('Failed to build pool')
         return 1
@@ -873,10 +879,10 @@ def create_virtual_network(**kargs):
         vf_dev = get_interface_by_pci_id(vf, _all_system_interfaces)
         _logger.debug('vf device for %s: %s' % (vf, vf_dev))
         if not create_networking(vf_dev,
-                             vnic['vlanTag'],
-                             vnic['macAddr'],
-                             vnic['privateIp'],
-                             int(vnic['subnetCidrBlock'].split('/')[1])):
+                                 vnic['vlanTag'],
+                                 vnic['macAddr'],
+                                 vnic['privateIp'],
+                                 int(vnic['subnetCidrBlock'].split('/')[1])):
             print_error('cannot create networking')
             destroy_networking(vf_dev, vnic['vlanTag'])
             return 1
@@ -901,10 +907,10 @@ def create_virtual_network(**kargs):
         _logger.debug(' device for nework %s' % vf_dev)
 
         if not create_networking(vf_dev,
-                            None,
-                            vnic['macAddr'],
-                            vnic['privateIp'],
-                            int(vnic['subnetCidrBlock'].split('/')[1])):
+                                 None,
+                                 vnic['macAddr'],
+                                 vnic['privateIp'],
+                                 int(vnic['subnetCidrBlock'].split('/')[1])):
             print_error('cannot create networking')
             destroy_networking(vf_dev)
             return 1
@@ -921,11 +927,11 @@ def create_virtual_network(**kargs):
 
     kvm_sysd_svc = SystemdServiceGenerator('kvm_net_%s' % kargs['network_name'], "KVM network")
     svc_envs = [('__KVM_NETWORK_NAME__', kargs['network_name']),
-        ('__KVM_NET_ADDRESS_SPACE__', _kvm_addr_space),
-        ('__KVM_NET_BRIDGE_NAME__', '%s0' % kargs['network_name']),
-        ('__VNIC_DEFAULT_GW__', vnic['virtualRouterIp']),
-        ('__RT_TABLE_NAME__', vf_dev),
-        ('__VNIC_PRIVATE_IP__', vnic['privateIp'])]
+                ('__KVM_NET_ADDRESS_SPACE__', _kvm_addr_space),
+                ('__KVM_NET_BRIDGE_NAME__', '%s0' % kargs['network_name']),
+                ('__VNIC_DEFAULT_GW__', vnic['virtualRouterIp']),
+                ('__RT_TABLE_NAME__', vf_dev),
+                ('__VNIC_PRIVATE_IP__', vnic['privateIp'])]
 
     if _is_bm_shape:
         svc_envs.append(('__NET_DEV__', '%s.%s' % (vf_dev, vnic['vlanTag'])))
@@ -1030,9 +1036,9 @@ def delete_virtual_network(**kargs):
     device_name_splitted = device_name.split('.')
     # we may not have vlanTag
     if len(device_name_splitted) == 1:
-        (vf_dev, vlanTag) = (device_name_splitted[0],None)
+        (vf_dev, vlanTag) = (device_name_splitted[0], None)
     else:
-        (vf_dev, vlanTag) = (device_name_splitted[0],device_name_splitted[1])
+        (vf_dev, vlanTag) = (device_name_splitted[0], device_name_splitted[1])
 
     fw_cmd = ['-t', 'nat', '-A', 'POSTROUTING', '-s']
     fw_cmd.append('%s/%s' % (ip_bridge, ip_prefix))

--- a/lib/oci_utils/kvm/virt.py
+++ b/lib/oci_utils/kvm/virt.py
@@ -800,6 +800,7 @@ def create_fs_pool(disk, name):
 
     # grab the uuid of the device
     _uuid = sudo_utils.call_output([LSBLK_CMD, '--output', 'uuid', '--noheadings', _new_part])
+    _uuid = _uuid.decode().strip()
 
     if sudo_utils.call([VIRSH_CMD, '--quiet', 'pool-define-as', '--name=%s' % name, '--type=fs', '--source-dev=/dev/disk/by-uuid/%s' % _uuid, '--target=/oci-%s' % name]):
         print_error('Failed to define pool')


### PR DESCRIPTION
change the way we create libvirt pool to use device uuid rather than device path which 
are not guarantied to be persistent 

test done : 

1 - create an instance
2 - create three block storage disk and attach them
3 - create two libvirt storage pools (on second and third block storage disk)
4 - verify that pool source is based on /dev/disk/by-uuid/....
4 - detach the first block storage  disk
5 - reboot 
6 - check state of storage pools