### PR TITLE
Multi vnic support

### DIFF
--- a/lib/oci_utils/impl/virt/oci-kvm-main.py
+++ b/lib/oci_utils/impl/virt/oci-kvm-main.py
@@ -67,10 +67,10 @@ def parse_args():
                                help='Name a of storage pool to be used for root disk')
     create_parser.add_argument('-s', '--disk-size', action='store', type=_disk_size_in_gb,
                                help='Size of the disk in GB to be created when using storage pool')
-    create_parser.add_argument('-n', '--net', action='store', type=str,
+    create_parser.add_argument('-n', '--net', action='store', action='append', type=str,
                                help='IP or name of the VNIC that should be attached '
                                     'to the VM')
-    create_parser.add_argument('-v', '--virtual-network', action='store', type=str,
+    create_parser.add_argument('-v', '--virtual-network', action='append', type=str,
                                help='The name of libvirt nework to attach the guest to')
     create_parser.add_argument('-D', '--domain', action='store', type=str,
                                help='Name of the virtual machine',
@@ -155,6 +155,15 @@ def create_vm(args):
         print("--net and --virtual_network option are exclusive", file=sys.stderr)
         return 1
 
+    # insure unicity in networking options in BM case
+
+    _all_net_names = set()
+    for n_name in args.net:
+        if n_name not in _all_net_names:
+            _all_net_names.add(n_name)
+        else:
+            print('duplicate virtual network name [%s], ignore it', vn_n)
+
     if '--network' in args.virt:
         sys.stderr.write(
             "--network is not a supported option. Please retry without "
@@ -164,7 +173,7 @@ def create_vm(args):
                                      root_disk=args.disk,
                                      pool=args.pool,
                                      disk_size=args.disk_size,
-                                     network=args.net, virtual_network=args.virtual_network, extra_args=args.virt)
+                                     network=list(_all_net_names), virtual_network=args.virtual_network, extra_args=args.virt)
 
 
 def destroy_vm(args):

--- a/lib/oci_utils/impl/virt/oci-kvm-main.py
+++ b/lib/oci_utils/impl/virt/oci-kvm-main.py
@@ -67,7 +67,7 @@ def parse_args():
                                help='Name a of storage pool to be used for root disk')
     create_parser.add_argument('-s', '--disk-size', action='store', type=_disk_size_in_gb,
                                help='Size of the disk in GB to be created when using storage pool')
-    create_parser.add_argument('-n', '--net', action='store', action='append', type=str,
+    create_parser.add_argument('-n', '--net', action='append', type=str,
                                help='IP or name of the VNIC that should be attached '
                                     'to the VM')
     create_parser.add_argument('-v', '--virtual-network', action='append', type=str,

--- a/man/man1/oci-kvm.1
+++ b/man/man1/oci-kvm.1
@@ -134,13 +134,13 @@ subcommand, specify the name of the pool. When not specified, the default name i
 When entering the
 .B create
 subcommand, on bare metal instance host, specify the IP address of the Oracle Cloud Infrastructure VNIC to be assigned to the new guest.
-On a virtual machine instance host,specify the name of the Oracle Cloud Infrastructure VNIC. If this
+On a virtual machine instance host,specify the name of the Oracle Cloud Infrastructure VNIC (can be repeated multiple times). If this
 option is not specified, an unused VNIC is chosen arbitrarily.
 For the
 .B create-network
 subcommand, specify the IP address of the Oracle Cloud Infrastructure VNIC that is needed to build the network.
 .IP "-v VIRTUAL_NETWORK, --virtual-network VIRTUAL_NETWORK"
-Specify the name of the libvirt virtual network to attach the guest to.
+Specify the name of the libvirt virtual network to attach the guest to (can be repeated multiple times).
 .IP "-N HOST, --netfshost HOST"
 For the
 .B create-pool


### PR DESCRIPTION
make --network option repeatable for guest creation.

tests done :
- create a guest with two intfs (based on two vNICs) on VM instance 
- create a guest with two intfs (based on two vNICs) on BM instance , install the OS , check availability of the two interfaces .