### PR TITLE
fix for LINUX-7672, pystun to python3

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,5 +1,5 @@
 Name: oci-utils
-Version: 0.11.2
+Version: 0.11.3
 Release: 0%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
@@ -172,6 +172,9 @@ rm -rf %{buildroot}
 /opt/oci-utils/tests/__init__*
 
 %changelog
+* Tue Aug 4 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.3
+- LINUX-7672 - fix for python3 byte handling issue.
+
 * Thu Jul 16 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.2
 - support for LVM root filesystem in oci-growfs
 

--- a/lib/oci_utils/packages/stun/__init__.py
+++ b/lib/oci_utils/packages/stun/__init__.py
@@ -103,6 +103,12 @@ def _initialize():
         dictValToMsgType.update({items[i][1]: items[i][0]})
 
 
+def _bin_to_hexstr(b):
+    if type(b) == bytes:
+        return binascii.b2a_hex(b).decode('utf-8')
+    return binascii.a2b_hex(b)
+
+
 def gen_tran_id():
     """
     Generate a random 32byte HEX string.
@@ -149,7 +155,7 @@ def stun_test(sock, host, port, source_ip, source_port, send_data=""):
     str_len = "%#04d" % (len(send_data) / 2)
     tranid = gen_tran_id()
     str_data = ''.join([BindRequestMsg, str_len, tranid, send_data])
-    data = binascii.a2b_hex(str_data)
+    data = _bin_to_hexstr(str_data)
     recv_corr = False
     while not recv_corr:
         recieved = False
@@ -174,43 +180,43 @@ def stun_test(sock, host, port, source_ip, source_port, send_data=""):
                 else:
                     ret_val['Resp'] = False
                     return ret_val
-        msgtype = binascii.b2a_hex(buf[0:2])
+        msgtype = _bin_to_hexstr(buf[0:2])
         bind_resp_msg = dictValToMsgType[msgtype] == "BindResponseMsg"
-        tranid_match = tranid.upper() == binascii.b2a_hex(buf[4:20]).upper()
+        tranid_match = tranid.upper() == _bin_to_hexstr(buf[4:20]).upper()
         if bind_resp_msg and tranid_match:
             recv_corr = True
             ret_val['Resp'] = True
-            len_message = int(binascii.b2a_hex(buf[2:4]), 16)
+            len_message = int(_bin_to_hexstr(buf[2:4]), 16)
             len_remain = len_message
             base = 20
             while len_remain:
-                attr_type = binascii.b2a_hex(buf[base:(base + 2)])
-                attr_len = int(binascii.b2a_hex(buf[(base + 2):(base + 4)]), 16)
+                attr_type = _bin_to_hexstr(buf[base:(base + 2)])
+                attr_len = int(_bin_to_hexstr(buf[(base + 2):(base + 4)]), 16)
                 if attr_type == MappedAddress:
-                    port = int(binascii.b2a_hex(buf[base + 6:base + 8]), 16)
+                    port = int(_bin_to_hexstr(buf[base + 6:base + 8]), 16)
                     ip = ".".join(
-                        [str(int(binascii.b2a_hex(buf[base + 8:base + 9]), 16)),
-                         str(int(binascii.b2a_hex(buf[base + 9:base + 10]), 16)),
-                         str(int(binascii.b2a_hex(buf[base + 10:base + 11]), 16)),
-                         str(int(binascii.b2a_hex(buf[base + 11:base + 12]), 16))])
+                        [str(int(_bin_to_hexstr(buf[base + 8:base + 9]), 16)),
+                         str(int(_bin_to_hexstr(buf[base + 9:base + 10]), 16)),
+                         str(int(_bin_to_hexstr(buf[base + 10:base + 11]), 16)),
+                         str(int(_bin_to_hexstr(buf[base + 11:base + 12]), 16))])
                     ret_val['ExternalIP'] = ip
                     ret_val['ExternalPort'] = port
                 if attr_type == SourceAddress:
-                    port = int(binascii.b2a_hex(buf[base + 6:base + 8]), 16)
+                    port = int(_bin_to_hexstr(buf[base + 6:base + 8]), 16)
                     ip = ".".join([
-                        str(int(binascii.b2a_hex(buf[base + 8:base + 9]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 9:base + 10]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 10:base + 11]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 11:base + 12]), 16))])
+                        str(int(_bin_to_hexstr(buf[base + 8:base + 9]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 9:base + 10]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 10:base + 11]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 11:base + 12]), 16))])
                     ret_val['SourceIP'] = ip
                     ret_val['SourcePort'] = port
                 if attr_type == ChangedAddress:
-                    port = int(binascii.b2a_hex(buf[base + 6:base + 8]), 16)
+                    port = int(_bin_to_hexstr(buf[base + 6:base + 8]), 16)
                     ip = ".".join([
-                        str(int(binascii.b2a_hex(buf[base + 8:base + 9]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 9:base + 10]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 10:base + 11]), 16)),
-                        str(int(binascii.b2a_hex(buf[base + 11:base + 12]), 16))])
+                        str(int(_bin_to_hexstr(buf[base + 8:base + 9]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 9:base + 10]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 10:base + 11]), 16)),
+                        str(int(_bin_to_hexstr(buf[base + 11:base + 12]), 16))])
                     ret_val['ChangedIP'] = ip
                     ret_val['ChangedPort'] = port
                 # if attr_type == ServerName:

--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,7 @@ if sys.version_info.major < 3:
 
 setup(
     name="oci-utils",
-    version="0.11.2",
+    version="0.11.3",
     author="Laszlo Peter, Qing Lin, Guido Tijskens, Emmanuel Jannetti",
     author_email="laszlo.peter@oracle.com, qing.lin@oracle.com, guido.tijskens@oracle.com, emmanuel.jannetti@oracle.com",
     description="Oracle Cloud Infrastructure utilities",


### PR DESCRIPTION
this change fixes a python3 compatibility issue in the stun code.
tests successfullyt executed on ol7 and ol8