### PR TITLE
fix for ACL-180:

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
 Version: 0.11.3
-Release: 0%{?dist}
+Release: 1%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -26,7 +26,13 @@ Requires: cloud-utils-growpart
 Requires: util-linux
 # for iscsiadm
 Requires: iscsi-initiator-utils
-
+#
+%if 0%{?rhel} == 7
+Requires: python36-netaddr
+%else
+Requires: network-scripts
+Requires: python3-netaddr
+%endif
 
 %description
 A package with useful scripts for querying/validating the state of Oracle Cloud Infrastructure instances running Oracle Linux and facilitating some common configuration tasks.
@@ -38,11 +44,8 @@ Requires: %{name} = %{version}-%{release}
 
 %if 0%{?rhel} >= 8
 Requires: python3-libvirt
-Requires: python3-netaddr
-Requires: network-scripts
 %else
 Requires: python36-libvirt
-Requires: python36-netaddr
 %endif
 
 %description kvm
@@ -172,6 +175,9 @@ rm -rf %{buildroot}
 /opt/oci-utils/tests/__init__*
 
 %changelog
+* Mon Aug 17 2020 Guido Tijskens <guido.tijskens@oracle.com> --0.11.3.1
+- ACL-180
+
 * Tue Aug 4 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.3
 - LINUX-7672 - fix for python3 byte handling issue.
 

--- a/lib/oci_utils/impl/auth_helper.py
+++ b/lib/oci_utils/impl/auth_helper.py
@@ -91,7 +91,10 @@ class OCIAuthProxy(object):
         resp = {'status': 'DEBUG'}
         while resp['status'] == 'DEBUG':
             line = self.helper.stdout.readline()
-            resp = json.loads(line.strip())
+            try:
+                resp = json.loads(line.strip())
+            except ValueError as e:
+                raise OCISDKError('%s is not valid JSON' % line.strip())
             if resp['status'] == 'ERROR':
                 raise OCISDKError('API Proxy error: %s' % resp['data'])
         return resp

--- a/lib/oci_utils/oci_api.py
+++ b/lib/oci_utils/oci_api.py
@@ -216,12 +216,13 @@ class OCISession(object):
             If the timeout is reached.
         """
         lock_thread(timeout=self._sdk_lock_timeout)
-        # for loggin purposes
+        # for login purposes
         call_name = str(client_func)
         try:
             call_name = client_func.__name__
         except Exception:
-            _logger.debug('function name not found', stack_info=True, exc_info=True)
+            _logger.debug('function name not found',
+                          stack_info=True, exc_info=True)
         try:
             result = client_func(*args, **kwargs)
             next_res = result
@@ -229,7 +230,8 @@ class OCISession(object):
                 next_res = client_func(*args, page=next_res.next_page, **kwargs)
                 result.data.extend(next_res.data)
         except Exception as e:
-            _logger.debug("API call %s failed: %s" % (call_name, e), stack_info=True, exc_info=True)
+            _logger.debug("API call %s failed: %s" % (call_name, e),
+                          stack_info=True, exc_info=True)
             raise
         finally:
             release_thread()
@@ -939,10 +941,10 @@ class OCISession(object):
                                           instance_id=instance_id).data
             return OCIInstance(self, instance_data)
         except Exception as e:
-            _logger.error('Failed to fetch instance: %s. \n'
+            _logger.debug('Failed to fetch instance: %s. \n'
                           'Check your connection and settings.' % e)
-
-        return None
+            raise OCISDKError('Failed to fetch instance %s' % instance_id)
+        # return None
 
     def get_subnet(self, subnet_id, refresh=False):
         """
@@ -966,7 +968,7 @@ class OCISession(object):
             return OCISubnet(self, subnet_data=sn_data)
         except oci_sdk.exceptions.ServiceError:
             _logger.debug('failed to get subnet', exc_info=True)
-            return None
+            # return None
 
         return None
 
@@ -1031,7 +1033,8 @@ class OCISession(object):
             raise Exception('ocid must be provided')
 
         try:
-            c_data = self._identity_client.get_compartment(compartment_id=kargs['ocid']).data
+            c_data = \
+                self._identity_client.get_compartment(compartment_id=kargs['ocid']).data
             return OCICompartment(session=self, compartment_data=c_data)
         except Exception as e:
             _logger.error('error getting compartment: %s' % e)


### PR DESCRIPTION
- netaddr package as requirement for oci-utils
- clean error reporting
includes also LINUX-7672, the bytes-string issue in stun package
.
the netaddr package which was only added for oci-kvm is needed for oci-utils;
modified errors generated by authentication to make them less confusing and more understandable.
.
tests run on el7 and el8, on OL7, AL7 and OL8