### PR TITLE
LINUX-7916 Error seen when creating a new vnic with oci-utils v0.11.3…

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
 Version: 0.11.3
-Release: 1%{?dist}
+Release: 2%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -175,7 +175,10 @@ rm -rf %{buildroot}
 /opt/oci-utils/tests/__init__*
 
 %changelog
-* Mon Aug 17 2020 Guido Tijskens <guido.tijskens@oracle.com> --0.11.3.1
+* Fri Aug 21 2020 Gudio Tijskens <guido.tijskens@oracle.com> --0.11.3-2
+- LINUX-7916 Error seen when creating a new vnic with oci-utils v0.11.3-0 on KVM image
+
+* Mon Aug 17 2020 Guido Tijskens <guido.tijskens@oracle.com> --0.11.3-1
 - ACL-180
 
 * Tue Aug 4 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.3

--- a/lib/oci_utils/impl/network_helpers.py
+++ b/lib/oci_utils/impl/network_helpers.py
@@ -83,7 +83,7 @@ def _get_link_infos(namespace):
     --------
         list of
         {
-            link : underlying link of thie interface (may be None)
+            link : underlying link of this interface (may be None)
             link_idx: underlying link index of thie interface (may be None)
             mac : mac address
             index : interface system index
@@ -139,7 +139,8 @@ def _get_link_infos(namespace):
         # grab VF mac if any
         if 'vfinfo_list' in obj:
             for _v in obj['vfinfo_list']:
-                _vfs_mac.append(_v['mac'])
+                if 'mac' in _v.keys():
+                    _vfs_mac.append(_v['mac'])
 
         if 'linkinfo' in obj:
             _addr_info['subtype'] = obj['linkinfo']['info_kind']


### PR DESCRIPTION
…-0 on KVM image
noticed the json option on ip --details can generate an empty vfinfo_list member; introduced check if the key 'mac' exists;
due to lack of test environment no real test is performed, 
filer confirmed in LINUX-7916 the command passed and the result is correct
.
