### PR TITLE
add package dependencies on OCI python sdk

### DIFF
--- a/buildrpm/oci-utils.spec
+++ b/buildrpm/oci-utils.spec
@@ -1,6 +1,6 @@
 Name: oci-utils
-Version: 0.11.4
-Release: 3%{?dist}
+Version: 0.11.5
+Release: 5%{?dist}
 Url: http://cloud.oracle.com/iaas
 Summary: Oracle Cloud Infrastructure utilities
 License: UPL
@@ -26,6 +26,7 @@ Requires: cloud-utils-growpart
 Requires: util-linux
 # for iscsiadm
 Requires: iscsi-initiator-utils
+Requires: python36-oci-sdk
 #
 %if 0%{?rhel} == 7
 Requires: python36-netaddr
@@ -175,6 +176,9 @@ rm -rf %{buildroot}
 /opt/oci-utils/tests/__init__*
 
 %changelog
+* Wed Sep 16 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.5
+- LINUX-6752 - add dependency on OCI python sdk
+
 * Tue Sep 15 2020 Emmanuel Jannetti <emmanuel.jannetti@oracle.com> --0.11.4
 - LINUX-7035 - introduce oci-notify tool to send notification to OCI notification service
 

--- a/doc/oci_api.md
+++ b/doc/oci_api.md
@@ -15,18 +15,6 @@ To use oci_api import oci_utils.oci_api:
 import oci_utils.oci_api
 ```
 
-You can do this even if the code is not running on an OCI instance and
-even if the OCI Python SDK is not installed.  To verify if the SDK is
-installed, use oci_utils.oci_api.HAVE_OCI_SDK:
-
-```python
-import sys
-import oci_utils.oci_api
-
-if not oci_utils.oci_api.HAVE_OCI_SDK:
-    sys.stderr.write("Please install and configure the OCI Python SDK\n")
-```
-
 Creating an OCISession() object will fail if the SDK isn't properly
 configured or authentication failed.  In this case an OCISDKError
 exception is thrown:

--- a/lib/oci_utils/impl/oci-iscsi-config-main.py
+++ b/lib/oci_utils/impl/oci-iscsi-config-main.py
@@ -876,16 +876,15 @@ def main():
 
     _user_euid = os.geteuid()
 
-    if oci_utils.oci_api.HAVE_OCI_SDK:
-        try:
-            oci_sess = oci_utils.oci_api.OCISession()
-            USE_OCI_SDK = True
-        except Exception as e:
-            _logger.debug('Cannot get OCI session: %s' % str(e))
-            oci_sdk_error = str(e)
-            USE_OCI_SDK = False
-            if args.debug:
-                raise
+    try:
+        oci_sess = oci_utils.oci_api.OCISession()
+        USE_OCI_SDK = True
+    except Exception as e:
+        _logger.debug('Cannot get OCI session: %s' % str(e))
+        oci_sdk_error = str(e)
+        USE_OCI_SDK = False
+        if args.debug:
+            raise
 
     if not os.path.isfile("/var/run/ocid.pid"):
         _logger.error("Warning:\n"

--- a/lib/oci_utils/impl/oci-network-config-main.py
+++ b/lib/oci_utils/impl/oci-network-config-main.py
@@ -122,18 +122,18 @@ def get_oci_api_session(opt_name=None):
             The session or None if cannot get one
     """
     sess = None
-    if oci_utils.oci_api.HAVE_OCI_SDK:
-        try:
-            sess = oci_utils.oci_api.OCISession()
-        except Exception as e:
-            sdk_error = str(e)
-            if opt_name is not None:
-                __logger.error("To use the %s option, you need to "
-                               "install and configure the OCI Python SDK "
-                               "(python36-oci-sdk)\n" % opt_name)
-                __logger.error(sdk_error)
-            else:
-                __logger.error("Failed to access OCI services: %s" % sdk_error)
+
+    try:
+        sess = oci_utils.oci_api.OCISession()
+    except Exception as e:
+        sdk_error = str(e)
+        if opt_name is not None:
+            __logger.error("To use the %s option, you need to "
+                           "install and configure the OCI Python SDK "
+                           "(python36-oci-sdk)\n" % opt_name)
+            __logger.error(sdk_error)
+        else:
+            __logger.error("Failed to access OCI services: %s" % sdk_error)
 
     return sess
 
@@ -208,8 +208,8 @@ def do_show_network_config(vnic_utils):
     -------
         No return value.
     """
-    if oci_utils.oci_api.HAVE_OCI_SDK:
-        api_show_network_config()
+
+    api_show_network_config()
 
     __logger.info("Operating System level network configuration")
 

--- a/lib/oci_utils/impl/oci_resources.py
+++ b/lib/oci_utils/impl/oci_resources.py
@@ -18,12 +18,7 @@ from .. import _MAX_VOLUMES_LIMIT, OCI_ATTACHMENT_STATE, \
     OCI_RESOURCE_STATE, OCI_INSTANCE_STATE, OCI_VOLUME_SIZE_FMT
 from ..exceptions import OCISDKError
 
-try:
-    import oci as oci_sdk
-except ImportError:
-    # if SDK not there none of resources is instanciated;
-    # i.e we never end up here
-    pass
+import oci as oci_sdk
 
 
 class OCICompartment(OCIAPIAbstractResource):
@@ -2206,7 +2201,8 @@ class OCIVolume(OCIAPIAbstractResource):
                 The size of the volume.
         """
         # for compatibility raseon we check against key as string
-        assert format_str in [OCI_VOLUME_SIZE_FMT.HUMAN.name, OCI_VOLUME_SIZE_FMT.GB.name,OCI_VOLUME_SIZE_FMT.MB.name], 'wrong format'
+        assert format_str in [OCI_VOLUME_SIZE_FMT.HUMAN.name,
+                              OCI_VOLUME_SIZE_FMT.GB.name, OCI_VOLUME_SIZE_FMT.MB.name], 'wrong format'
 
         if (format_str is None) or (format_str == OCI_VOLUME_SIZE_FMT.GB.name):
             return self._data.size_in_gbs

--- a/lib/oci_utils/impl/ocid-main.py
+++ b/lib/oci_utils/impl/ocid-main.py
@@ -213,15 +213,15 @@ def public_ip_func(context, func_logger):
     dict
         Dictionary containiong the external IP address.
     """
-    if oci_utils.oci_api.HAVE_OCI_SDK:
-        try:
-            sess = oci_utils.oci_api.OCISession()
-            instance = sess.this_instance()
-            if instance is None:
-                raise OCISDKError('Cannot get instance')
-            return {'publicIp': instance.get_public_ip()}
-        except OCISDKError as e:
-            func_logger.exception('failed to retrieve public ip information')
+
+    try:
+        sess = oci_utils.oci_api.OCISession()
+        instance = sess.this_instance()
+        if instance is None:
+            raise OCISDKError('Cannot get instance')
+        return {'publicIp': instance.get_public_ip()}
+    except OCISDKError as e:
+        func_logger.exception('failed to retrieve public ip information: %s' % str(e))
 
     # fallback
     external_ip = get_ip_info()[1]
@@ -246,11 +246,10 @@ def iscsi_func(context, func_logger):
     """
     if 'oci_sess' not in context:
         oci_sess = None
-        if oci_utils.oci_api.HAVE_OCI_SDK:
-            try:
-                oci_sess = oci_utils.oci_api.OCISession()
-            except Exception:
-                pass
+        try:
+            oci_sess = oci_utils.oci_api.OCISession()
+        except Exception as e:
+            func_logger.debug('Failed to get a session: %s' % str(e))
         max_volumes = 8
         if 'max_volumes' in context:
             max_volumes = int(context['max_volumes'])
@@ -533,11 +532,10 @@ def vnic_func(context, func_logger):
         func_logger.debug("context['vnic_utils'] is None : first iteration")
         # first iteration
         oci_sess = None
-        if oci_utils.oci_api.HAVE_OCI_SDK:
-            try:
-                oci_sess = oci_utils.oci_api.OCISession()
-            except Exception:
-                func_logger.debug("error getting session")
+        try:
+            oci_sess = oci_utils.oci_api.OCISession()
+        except Exception as e:
+            func_logger.debug("error getting session: %s" % str(e))
         context['oci_sess'] = oci_sess
         context['vnic_utils'] = vnicutils.VNICUtils()
         context['vnic_info_ts'], context['vnic_info'] = \

--- a/lib/oci_utils/oci_api.py
+++ b/lib/oci_utils/oci_api.py
@@ -11,7 +11,7 @@ import logging
 import os
 import re
 from time import sleep
-
+import oci as oci_sdk
 import oci_utils
 from oci_utils import metadata
 from . import _configuration as OCIUtilsConfiguration
@@ -20,12 +20,6 @@ from .exceptions import OCISDKError
 from .impl import lock_thread, release_thread
 from .impl.auth_helper import OCIAuthProxy
 from .impl.oci_resources import (OCICompartment, OCIInstance, OCIVolume, OCISubnet)
-
-HAVE_OCI_SDK = True
-try:
-    import oci as oci_sdk
-except ImportError:
-    HAVE_OCI_SDK = False
 
 # authentication methods
 DIRECT = 'direct'
@@ -63,13 +57,8 @@ class OCISession(object):
         Raises
         ------
         OCISDKError
-            If there is no OCI SDK,
             if fails to authenticate.
         """
-
-        global HAVE_OCI_SDK
-        if not HAVE_OCI_SDK:
-            raise OCISDKError('Package python36-oci-sdk not installed')
 
         self.config_file = config_file
         self.config_profile = config_profile

--- a/libexec/oci-utils-config-helper
+++ b/libexec/oci-utils-config-helper
@@ -47,10 +47,6 @@ def main():
         int
             0
     """
-    if not oci_utils.oci_api.HAVE_OCI_SDK:
-        response('ERROR', data="OCI Python SDK not installed")
-        return 1
-
     try:
         session = oci_utils.oci_api.OCISession(
             auth_method=oci_utils.oci_api.DIRECT)

--- a/man/man1/oci-iscsi-config.1
+++ b/man/man1/oci-iscsi-config.1
@@ -59,15 +59,10 @@ which is then able to display all information without root privileges.
 It also attaches/detaches devices automatically if they do not require
 manual interaction.
 
-Additional features of
 .B oci-iscsi-config
-are available when the Oracle Cloud Infrastructure Python SDK is installed and configured.  The
-Oracle Cloud Infrastructure Python SDK is available in the python-oci-sdk package.  When available,
-.B oci-iscsi-config
-displays additional information about the iSCSI devices and can display all
+uses the OCI python SDK to display additional information about the iSCSI devices and can display all
 available Oracle Cloud Infrastructure storage volumes, not just the ones already assigned to the
-instance.  The second version of the command line requires the Oracle Cloud Infrastructure Python
-SDK.  This invocation can be used to create a new Oracle Cloud Infrastructure storage volume and
+instance.  The second version of the command can be used to create a new Oracle Cloud Infrastructure storage volume and
 assign it to the instance without the use of the Web-based Oracle Cloud Infrastructure Console,
 or to destroy a volume that is not attached to any instances.
 
@@ -75,7 +70,7 @@ To install the Oracle Cloud Infrastructure Python SDK, use
 .PP
 .nf
 .RS
-yum install python-oci-sdk python-oci-cli
+yum install python36-oci-sdk python-oci-cli
 .RE
 .fi
 .PP

--- a/man/man1/oci-network-config.1
+++ b/man/man1/oci-network-config.1
@@ -75,9 +75,9 @@ oci-network-config \- configure network devices on Oracle Cloud Infrastructure c
 
 The
 .B oci-network-config
-utility shows the current 
-Virtual interface Cards provisioned in the 
-Oracle Cloud Infrastructure 
+utility shows the current
+Virtual interface Cards provisioned in the
+Oracle Cloud Infrastructure
 and configured on this instance. When a secondary VNIC is provisioned in Oracle Cloud Infrastructure it must be explicitly configured on the instance using this script or similar commands.
 
 The first version of this command displays the currently provisioned VNICs and the current IP configuration for this instance. VNICs that are not yet configured are marked with '$ADD' and IP configurations that no longer have an associated VNIC are marked with '$DELETE'.
@@ -90,16 +90,14 @@ Bare Metal secondary VNICs are configured using VLANs (where there is no corresp
 
 The third version, -d (or --deconfigure), deletes all IP configuration for provisioned secondary VNICs as long as there is no -e option. If one or more optional -e options are present only the given secondary IP addresses are deconfigured and the remaining configuration is left as is.
 
-The fourth version requires the Oracle Cloud Infrastructure Python SDK to be installed and configured.
-The Oracle Cloud Infrastructure Python SDK is available in the python-oci-sdk package.  This version
-allows creating a new VNIC for the instance, detaching a VNIC from the instance,
+The fourth version allows creating a new VNIC for the instance, detaching a VNIC from the instance,
 or adding/removing private IP addresses to/from an existing VNIC.
 
 To install the Oracle Cloud Infrastructure Python SDK, use
 .PP
 .nf
 .RS
-yum install python-oci-sdk python-oci-cli
+yum install python36-oci-sdk python-oci-cli
 .RE
 .fi
 .PP

--- a/man/man1/oci-network-inspector.1
+++ b/man/man1/oci-network-inspector.1
@@ -9,9 +9,9 @@
 .SH NAME
 oci-network-inspector \- display Oracle Cloud Infrastructure networking information.
 .SH SYNOPSIS
-.B oci-network-inspector [--help] [-C 
+.B oci-network-inspector [--help] [-C
 .I COMPARTMENT_OCID
-.B | --compartment 
+.B | --compartment
 .I COMPARTMENT_OCID
 .B ] [-N
 .I VCN_OCID
@@ -23,9 +23,9 @@ The
 .B oci-network-inspector
 utility is used to display networking information for a given VCN or compartment, or for the configured tenancy in the Oracle Cloud Infrastructure.  By default, all VCNs in all compartments accessible by the user will be displayed.
 
-It lists detailed information including security list, IP addresses and associated VNICs and instances in all of the subnets of a given VCN, compartment or the tenancy. 
+It lists detailed information including security list, IP addresses and associated VNICs and instances in all of the subnets of a given VCN, compartment or the tenancy.
 
-It works on any system that has python-oci-sdk installed and configured to authenticate with an Oracle Cloud Infrastructure API server.
+It works on any system that has python36-oci-sdk installed and configured to authenticate with an Oracle Cloud Infrastructure API server.
 .SH OPTIONS
 .IP "-C COMPARTMENT_OCID, --compartment COMPARTMENT_OCID"
 Specify the compartment you wish to inspect.

--- a/man/man1/oci-public-ip.1
+++ b/man/man1/oci-public-ip.1
@@ -50,8 +50,7 @@ option to print the list of STUN servers.
 Print a list of known STUN servers.
 .IP "--instance-id OCID"
 Display the public IP address of the given instance
-instead of the current one. Requires the Oracle Cloud Infrastructure Python
-SDK (python-oci-sdk package) to be installed and configured.
+instead of the current one.
 .IP --debug
 Print diagnostic messages.
 .IP --help

--- a/man/man8/ocid.8
+++ b/man/man8/ocid.8
@@ -49,13 +49,13 @@ also caches the public IP address of the Oracle Cloud Infrastructure instance.
 
 To allow
 .BR ocid(8)
-to use Oracle Cloud Infrastructure APIs it requires Oracle Cloud Infrastructure Python SDK, which is available in the python-oci-sdk package.
+to use Oracle Cloud Infrastructure APIs it requires Oracle Cloud Infrastructure Python SDK, which is available in the python36-oci-sdk package.
 
 To install the Oracle Cloud Infrastructure Python SDK, use
 .PP
 .nf
 .RS
-yum install python-oci-sdk python-oci-cli
+yum install python36-oci-sdk python-oci-cli
 .RE
 .fi
 .PP

--- a/setup.py
+++ b/setup.py
@@ -362,7 +362,7 @@ if sys.version_info.major < 3:
 
 setup(
     name="oci-utils",
-    version="0.11.4",
+    version="0.11.5",
     author="Laszlo Peter, Qing Lin, Guido Tijskens, Emmanuel Jannetti",
     author_email="laszlo.peter@oracle.com, qing.lin@oracle.com, guido.tijskens@oracle.com, emmanuel.jannetti@oracle.com",
     description="Oracle Cloud Infrastructure utilities",


### PR DESCRIPTION
LINUX-6752

Added dependency on python36-oci-sdk
Removed code dealing with SDK not  found

test:
.1 install the package : check that dependency is also installed 
.2 remove the package : check dependency is remove
.3 run CLIs to verify good behaviour
