### PR TITLE
161 os network config output mode

### DIFF
--- a/lib/oci_utils/impl/oci_network_config_main.py
+++ b/lib/oci_utils/impl/oci_network_config_main.py
@@ -124,6 +124,28 @@ def def_show_parser(s_parser):
     return show_parser
 
 
+def def_show_os_parser(s_parser):
+    """
+    Define the show_os subparser.
+
+    Parameters
+    ----------
+    s_parser: subparsers.
+
+    Returns
+    -------
+        ArgumentParser: the show subcommand parser.
+    """
+    show_os_parser = s_parser.add_parser('show-os',
+                                      description='Display the current network interface configuration as well as the VNIC configuration from OCI.',
+                                      help='Display the current network interface configuration as well as the VNIC configuration from OCI.')
+    show_os_parser.add_argument('--output-mode',
+                             choices=('parsable', 'table', 'json', 'text'),
+                             help='Set output mode.',
+                             default='table')
+    return show_os_parser
+
+
 def def_show_vnics_parser(s_parser):
     """
     Define the show_vnics subparser
@@ -532,6 +554,9 @@ def get_arg_parser():
     #
     # show
     _ = def_show_parser(subparser)
+    #
+    # show-os
+    _ = def_show_os_parser(subparser)
     #
     # show-vnics
     _ = def_show_vnics_parser(subparser)
@@ -1002,6 +1027,25 @@ def update_network_config(nw_conf):
     return nw_conf
 
 
+def do_show_os_network_config(show_args):
+    """
+    Display the current network interface configuration as well as the VNIC configuration from OCI.
+
+    Parameters
+    ----------
+    show_args: namespace
+        The command line arguments.
+
+    Returns
+    -------
+        int: 0 on success, 1 otherwise.
+    """
+    _logger.debug('%s', where_am_i())
+    vnic_utils = get_vnic_utils(show_args)
+    show_os_network_config(vnic_utils, show_args.output_mode)
+    return 0
+
+
 def show_os_network_config(vnic_utils, mode):
     """
     Display the current network interface configuration as well as the VNIC configuration from OCI.
@@ -1011,7 +1055,7 @@ def show_os_network_config(vnic_utils, mode):
     vnic_utils :
         The VNIC configuration instance.
 
-    mode :
+    mode : str
         The output mode
 
     Returns
@@ -2041,6 +2085,7 @@ def main():
     """
     sub_commands = {'usage': show_usage,
                     'show': show_network,
+                    'show-os': do_show_os_network_config,
                     'show-vnics': show_vnics,
                     'show-vnics-all': show_vnics_all,
                     'show-vcns': show_vcns,

--- a/lib/oci_utils/impl/oci_network_config_main.py
+++ b/lib/oci_utils/impl/oci_network_config_main.py
@@ -23,6 +23,7 @@ from oci_utils.impl.network_helpers import is_valid_ip_address
 from oci_utils.impl.oci_resources import OCIVNIC
 from oci_utils.impl.row_printer import TablePrinter
 from oci_utils.impl.row_printer import TextPrinter
+from oci_utils.impl.row_printer import get_row_printer_impl
 from oci_utils.impl.row_printer_helpers import IndentPrinter
 from oci_utils.impl.row_printer_helpers import get_value_data
 from oci_utils.impl.row_printer_helpers import initialise_column_lengths
@@ -1001,7 +1002,7 @@ def update_network_config(nw_conf):
     return nw_conf
 
 
-def show_os_network_config(vnic_utils):
+def show_os_network_config(vnic_utils, mode):
     """
     Display the current network interface configuration as well as the VNIC configuration from OCI.
 
@@ -1009,6 +1010,9 @@ def show_os_network_config(vnic_utils):
     ----------
     vnic_utils :
         The VNIC configuration instance.
+
+    mode :
+        The output mode
 
     Returns
     -------
@@ -1034,8 +1038,8 @@ def show_os_network_config(vnic_utils):
                 ['STATE', 6, 'STATE'],
                 ['MAC', 18, 'MAC'],
                 ['VNIC ID', 95, 'VNIC'])
-    printer = TablePrinter(title=_title, columns=_columns, column_separator=' ', text_truncate=False)
-
+    printerKlass = get_row_printer_impl(mode)
+    printer = printerKlass(title=_title, columns=_columns, text_truncate=False)
     printer.printHeader()
     for item in ret:
         printer.printRow(item)
@@ -1062,8 +1066,7 @@ def show_network(show_args):
     network_config = vnic_utils.get_network_config()
     network_config = update_network_config(network_config)
     #
-    # for compatibility mode, oci-network-config show should provide the same output as oci-network-config --show;
-    # if output-mode is specified, compatiblity requirement is dropped.
+    # for compatibility mode (when compat-ouptut is set), oci-network-config show should provide the same output as oci-network-config --show;
     showerror = False
     if show_args.compat_output:
         compat_show_vnics_information()
@@ -1074,8 +1077,8 @@ def show_network(show_args):
             _logger.debug('Cannot show information', exc_info=True)
             _logger.error('Cannot show information: %s', str(e))
             showerror = True
-    if show_args.output_mode == 'table':
-        show_os_network_config(vnic_utils)
+    if not show_args.compat_output:
+        show_os_network_config(vnic_utils, show_args.output_mode)
     return False if showerror else True
 
 

--- a/man/man1/oci-network-config.1
+++ b/man/man1/oci-network-config.1
@@ -17,6 +17,9 @@ usage
 show [-h|--help] [-I ITEM|--include ITEM] [-X ITEM|--exclude ITEM] [--output-mode MODE] [--details]
 
 .B oci-network-config
+show-os [-h|--help] [--output-mode MODE]
+
+.B oci-network-config
 show-vcns [-h|--help] [--output-mode MODE] [--details] [--ocid VCN_OCID] [--name VCN_NAME] [--no-truncate]
 
 .B oci-network-config


### PR DESCRIPTION
Fixes #161 

This change:

- updates the `show_os_network_config` function to support the `output-mode` option.
- adds a new subcommand `show-os` to display only the OS network information.

I have a few things that I was unsure about:

- Naming - I've created a new wrapper function `do_show_os_network_config`. I've only used the `do_` prefix because I've seen it elsewhere. It's not ideal, and the two functions could possibly be merged.
- Updating the `oci-network-config` command. In my testing, I couldn't seem my new subcommand.

